### PR TITLE
Consider connection as valid if its state is 'fetch_schema'

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -489,7 +489,7 @@ replicaset_mt.__index = index
 local replica_mt = {
     __index = {
         is_connected = function(replica)
-            return replica.conn and replica.conn.state == 'active'
+            return replica.conn and replica.conn:is_connected()
         end,
         safe_uri = function(replica)
             local uri = luri.parse(replica.uri)


### PR DESCRIPTION
Before this patch is_connected returned true
only if connection state was 'active'.
However if call modified schema, connecton state
changed to 'fetch_schema' that led to reconnect

This patch fixes this behaviour and saves is_connecton
status then schema fetching.

Closes #199

Related https://github.com/tarantool/tarantool/commit/d0e333191d3f81aa3ed035ce2ce53e74a18417c1