### PR TITLE
Add TARANTOOL external dependency to rockspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ cmake_install.cmake
 packpack
 build
 *.reject
+.rocks
+build.luarocks
+.DS_Store

--- a/vshard-scm-1.rockspec
+++ b/vshard-scm-1.rockspec
@@ -12,6 +12,13 @@ description = {
 dependencies = {
     'tarantool >= 1.9.0';
 }
+
+external_dependencies = {
+    TARANTOOL = {
+        header = 'tarantool/module.h',
+    },
+}
+
 build = {
     type = 'cmake';
     variables = {


### PR DESCRIPTION
* This patch solves problem with missing TARANTOOL_INCLUDE_DIR
  cmake error, which occurs due to tarantool installation
  directory differs from default.