### PR TITLE
discovery based on active buckets

### DIFF
--- a/vshard/router/init.lua
+++ b/vshard/router/init.lua
@@ -310,7 +310,7 @@ discovery_f = function(router)
             if not active_buckets then
                 log.error('Error during discovery %s: %s', replicaset, err)
             else
-                discovery_handle_buckets(router, replicaset, buckets)
+                discovery_handle_buckets(router, replicaset, active_buckets)
             end
             lfiber.sleep(consts.DISCOVERY_INTERVAL)
         end


### PR DESCRIPTION
In my opinion, discovery should be based on active buckets rather than just buckets. We(Loco company) faced an issue in the morning. We fixed it by doing this in our router instances. 