### PR TITLE
travis-ci: move rockspec publishing into separate stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ cache:
 git:
     depth: 100500
 
+stages:
+  - test
+  - name: publish_rockspec
+    if: branch = master OR tag IS present
+  - deploy
+
 env:
     global:
       - PRODUCT=tarantool-vshard
@@ -154,7 +160,7 @@ notifications:
 
 jobs:
   include:
-    - stage: deploy
+    - stage: publish_rockspec
       script: skip
       deploy:
         - provider: script


### PR DESCRIPTION
Sometimes "deploy" stage fails it prevents the update of rockspec.
To avoid this let's move rockspec publishing into separate stage.