### PR TITLE
travis-ci: remove before_deploy section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ script:
   - git clone https://github.com/packpack/packpack.git packpack
   - packpack/packpack -e PACKPACK_GIT_SOURCEDIR=/source/
 
-before_deploy:
-  - ls -l build/
-
 deploy:
   # Deploy packages to PackageCloud from master branch
   - provider: packagecloud


### PR DESCRIPTION
This section doesn't do anything useful but leads to fail for some
stages. This patch just removes it.