### PR TITLE
Reconnection replica in case uuid mismatches

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -70,6 +70,12 @@ local function netbox_on_connect(conn)
         log.info('Mismatch server UUID on replica %s: expected "%s", but got '..
                  '"%s"', replica, replica.uuid, conn.peer_uuid)
         conn:close()
+        fiber.new(function()
+            -- Workaround for https://github.com/tarantool/vshard/issues/241
+            -- Keep reconnection attempts even if uuid mismatch
+            fiber.sleep(consts.RECONNECT_TIMEOUT)
+            rs:connect_replica(replica)
+        end)
         return
     end
     if replica == rs.replica and replica == rs.priority_list[1] then


### PR DESCRIPTION
In cartridge there is another iproto server implementation
(remote-control) used for accessing uninitialized instances with
`net.box`. It always reports `peer.uuid == require('uuid').NULL`. During
cluster initialization there may be a race: `vshard.router` could be
initialized earlier than `vshard.storage`, so the router establishes
connection to remote-control.

As a result, vshard router sees uuid mismatch and closes conection and
never tries to reconnect. So we stay with disconnected replica until
next reconfiguration.

This patch preserves reconnection attempts even in case uuid mismatches.

Close #241