### PR TITLE
Skip uuid mismatch with cartridge.remote-control

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -51,6 +51,7 @@ local consts = require('vshard.consts')
 local lerror = require('vshard.error')
 local fiber = require('fiber')
 local luri = require('uri')
+local luuid = require('uuid')
 local ffi = require('ffi')
 local util = require('vshard.util')
 local gsc = util.generate_self_checker
@@ -59,6 +60,12 @@ local gsc = util.generate_self_checker
 -- on_connect() trigger for net.box
 --
 local function netbox_on_connect(conn)
+    -- Workaround for https://github.com/tarantool/vshard/issues/241
+    -- Ignore connections to cartridge.remote-control server
+    if conn.peer_uuid == luuid.NULL:str() then
+        return
+    end
+
     log.info("connected to %s:%s", conn.host, conn.port)
     local rs = conn.replicaset
     local replica = conn.replica


### PR DESCRIPTION
This is an alternative to #242, which is incorrect. 

In cartridge there is another iproto server implementation
(remote-control) used for accessing uninitialized instances with
`net.box`. It always reports `peer.uuid == require('uuid').NULL`. During
cluster initialization there may be a race: `vshard.router` could be
initialized earlier than `vshard.storage`, so the router establishes
connection to remote-control.

As a result, vshard router sees uuid mismatch and closes conection and
never tries to reconnect. So we stay with disconnected replica until
next reconfiguration.

This patch ignores mismatch when `peer.uuid == require('uuid').NULL`.

Anyway, tarantool instance can't have real uuid equal to NULL. An
attempt to bootstrap instance with NULL uuid raises the error
"Incorrect value for option 'instance_uuid': nil UUID is reserved".

Close #241