### PR TITLE
test: fix parallel.test.lua and sync.test.lua

### DIFF
--- a/test/rebalancer/engine.cfg
+++ b/test/rebalancer/engine.cfg
@@ -15,7 +15,7 @@
         "memtx": {"engine": "memtx"},
         "vinyl": {"engine": "vinyl"}
     },
-    "workers.test.lua": {
+    "parallel.test.lua": {
         "memtx": {"engine": "memtx"},
         "vinyl": {"engine": "vinyl"}
     }

--- a/test/storage/sync.result
+++ b/test/storage/sync.result
@@ -28,9 +28,6 @@ util.wait_master(test_run, REPLICASET_1, 'storage_1_a')
 util.wait_master(test_run, REPLICASET_2, 'storage_2_a')
 ---
 ...
-util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, 'bootstrap_storage(\'%s\')', engine)
----
-...
 _ = test_run:switch('storage_1_a')
 ---
 ...

--- a/test/storage/sync.test.lua
+++ b/test/storage/sync.test.lua
@@ -8,7 +8,6 @@ test_run:create_cluster(REPLICASET_2, 'storage')
 util = require('util')
 util.wait_master(test_run, REPLICASET_1, 'storage_1_a')
 util.wait_master(test_run, REPLICASET_2, 'storage_2_a')
-util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, 'bootstrap_storage(\'%s\')', engine)
 
 _ = test_run:switch('storage_1_a')
 s = box.schema.create_space('test')


### PR DESCRIPTION
With the current version of test-run, that vshard uses now (d171b6e),
all tests work fine and everything is ok. The problem occures when
attempting to use a later version of test-run starting since 53389a8.
In this case, the parallel.test.lua and sync.test.lua tests start to
fail because the new test-run version catches some exception from tests
and exits with a failure.

This patch should be concidered as a preparation for updating test-run
version for vshard.