### PR TITLE
ci: add workflow to run against tarantool build

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -1,0 +1,45 @@
+name: reusable_testing
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: 'The name of the tarantool build artifact'
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Clone the vshard module'
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/vshard
+          # Fetch the entire history for all branches and tags. It is needed for
+          # upgrade testing.
+          fetch-depth: 0
+          # Enable recursive submodules checkout as test-run git module is used
+          # for running tests.
+          submodules: recursive
+      - name: 'Download the tarantool build artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+      # TODO(ylobankov): Just in case remove tarantool that could be previously
+      # installed on the runner. Relevant to self-hosted runners. Remove this
+      # step when only GitHub-hosted runners are used for integration testing.
+      - run: sudo apt-get -y purge 'tarantool*'
+      - name: 'Install tarantool'
+        # TODO(ylobankov): Install package dependencies. Now we're lucky: all
+        # dependencies are already there.
+        run: sudo dpkg -i tarantool*.deb
+      - name: 'Install test requirements'
+        run: pip3 install --user -r test-run/requirements.txt
+      - run: cmake .
+      - run: make test
+      # TODO(ylobankov): Relevant to self-hosted runners. Remove this step
+      # when only GitHub-hosted runners are used for integration testing.
+      - if: always()
+        run: sudo apt-get -y purge 'tarantool*'


### PR DESCRIPTION
The idea of this workflow is to be a pluggable part of some other
workflow from any repo to verify the integration of the vshard module
with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
corresponding workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
vshard.

Part of tarantool/tarantool#4972
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056