### PR TITLE
ci: disable fail-fast behaviour for tests

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -44,4 +44,4 @@ jobs:
         run: pip3 install --user -r test-run/requirements.txt
 
       - run: cmake .
-      - run: make test
+      - run: make test-force

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 'Install test requirements'
         run: pip3 install --user -r test-run/requirements.txt
       - run: cmake .
-      - run: make test
+      - run: make test-force
       # TODO(ylobankov): Relevant to self-hosted runners. Remove this step
       # when only GitHub-hosted runners are used for integration testing.
       - if: always()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,3 +6,9 @@ add_custom_target(test
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j -1
         --builddir=${PROJECT_BINARY_DIR}
         --vardir=${PROJECT_BINARY_DIR}/test/var)
+
+add_custom_target(test-force
+    COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j -1
+        --builddir=${PROJECT_BINARY_DIR}
+        --vardir=${PROJECT_BINARY_DIR}/test/var
+        --force)


### PR DESCRIPTION
Problem: when tests start and one of them fails, the test run stops, and
other tests are not executed, we exit after the first test failure. It's
not convenient since as a developer I would like to see all test results
and understand the impact of my changes on all project functionalities.