### PR TITLE
router: support return_raw in map_callrw()

### DIFF
--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -21,9 +21,13 @@ end
 local function config_new(templ)
     local res = table.deepcopy(templ)
     local sharding = {}
+    local meta = {replicasets = {}}
     res.sharding = sharding
-    for _, replicaset_templ in pairs(templ.sharding) do
+    for i, replicaset_templ in pairs(templ.sharding) do
         local replicaset_uuid = uuid_next()
+        meta.replicasets[i] = {
+            uuid = replicaset_uuid
+        }
         local replicas = {}
         local replicaset = table.deepcopy(replicaset_templ)
         replicaset.replicas = replicas
@@ -36,7 +40,7 @@ local function config_new(templ)
         end
         sharding[replicaset_uuid] = replicaset
     end
-    return res
+    return res, meta
 end
 
 --

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -2571,7 +2571,10 @@ local function storage_map(rid, name, args)
     if not ok then
         return nil, err
     end
-    return true, res
+    if res ~= nil then
+        return true, res
+    end
+    return true
 end
 
 local function storage_service_info()


### PR DESCRIPTION
Closes #312

@TarantoolBot document
Title: vshard.router.map_callrw() format of `return_raw` result

`vshard.router.map_callrw()` supports `return_raw` option (in the
version of Tarantool which have it at all).

When there was an error, the result is the same as always:
`nil, err, err_uuid`. No changes.

When the call was a success, the result is a map of the format
`{[replicaset_uuid] = msgpack.object}`. The `msgpack.object` here
stores a MessagePack array with the results returned from the
storage's map-function.

The usecase is the same as for when bare netbox is used - to avoid
decoding of the results into Lua land. Helpful when the router is
used as a proxy and the results received from the storage are big.

Example:
```Lua
local res = vshard.router.map_callrw('my_func', args, {..., return_raw = true})

for replicaset_uuid, msgpack_value in pairs(res) do
    log.info('Replicaset %s returned %s', replicaset_uuid,
             msgpack_value:decode())
end
```
However this is just an example. Normally you don't need `return_raw` if you are
calling `:decode()` anyway.

The family of `vshard.router.call` functions also supports `return_raw`, but
their behaviour is the same as with bare netbox - the entire result is just an
`msgpack.object`. The same as if direct netbox call would be done. Nothing to
document here, I think.