### PR TITLE
test: new check for timeout errors from net.box

### DIFF
--- a/test/lua_libs/util.lua
+++ b/test/lua_libs/util.lua
@@ -201,6 +201,12 @@ local function portable_error(err)
     return {type = err.type, message = err.message}
 end
 
+-- Function to check if the error is a timeout error. The function
+-- works for old and new error type in net.box functions.
+function is_timeout_error(err)
+    return 'Timeout exceeded' == err.message or 'timed out' == err.message
+end
+
 return {
     check_error = check_error,
     shuffle_masters = shuffle_masters,
@@ -215,4 +221,5 @@ return {
     BUILDDIR = BUILDDIR,
     git_checkout = git_checkout,
     portable_error = portable_error,
+    is_timeout_error = is_timeout_error,
 }

--- a/test/rebalancer/receiving_bucket.result
+++ b/test/rebalancer/receiving_bucket.result
@@ -221,10 +221,9 @@ _ = test_run:switch('box_2_a')
 _, err = vshard.storage.bucket_send(101, util.replicasets[1], {timeout = 0.1})
 ---
 ...
-util.portable_error(err)
+util.is_timeout_error(err)
 ---
-- type: ClientError
-  message: Timeout exceeded
+- true
 ...
 box.space._bucket:get{101}
 ---

--- a/test/rebalancer/receiving_bucket.test.lua
+++ b/test/rebalancer/receiving_bucket.test.lua
@@ -89,7 +89,7 @@ _ = test_run:switch('box_1_a')
 vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 _ = test_run:switch('box_2_a')
 _, err = vshard.storage.bucket_send(101, util.replicasets[1], {timeout = 0.1})
-util.portable_error(err)
+util.is_timeout_error(err)
 box.space._bucket:get{101}
 while box.space._bucket:get{101}.status ~= vshard.consts.BUCKET.ACTIVE do vshard.storage.recovery_wakeup() fiber.sleep(0.01) end
 box.space._bucket:get{101}

--- a/test/router/map-reduce.result
+++ b/test/router/map-reduce.result
@@ -187,9 +187,9 @@ _ = test_run:switch('router_1')
 ok, err = vshard.router.map_callrw('echo', {1}, timeout_opts)
  | ---
  | ...
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
  | ---
- | - Timeout exceeded
+ | - true
  | ...
 
 _ = test_run:switch('storage_2_a')
@@ -237,9 +237,9 @@ _ = test_run:switch('router_1')
 ok, err = vshard.router.map_callrw('echo', {1}, timeout_opts)
  | ---
  | ...
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
  | ---
- | - Timeout exceeded
+ | - true
  | ...
 
 _ = test_run:switch('storage_1_a')

--- a/test/router/map-reduce.test.lua
+++ b/test/router/map-reduce.test.lua
@@ -74,7 +74,7 @@ lsched.move_start(big_timeout)
 
 _ = test_run:switch('router_1')
 ok, err = vshard.router.map_callrw('echo', {1}, timeout_opts)
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
 
 _ = test_run:switch('storage_2_a')
 lsched = require('vshard.storage.sched')
@@ -94,7 +94,7 @@ assert(lref.count == 0)
 
 _ = test_run:switch('router_1')
 ok, err = vshard.router.map_callrw('echo', {1}, timeout_opts)
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
 
 _ = test_run:switch('storage_1_a')
 test_run:wait_cond(function() return lref.count == 0 end)

--- a/test/router/retry_reads.result
+++ b/test/router/retry_reads.result
@@ -123,10 +123,9 @@ util.portable_error(e)
 _, e = rs1:callro('sleep', {1}, {timeout = 0.0001})
 ---
 ...
-util.portable_error(e)
+util.is_timeout_error(e)
 ---
-- type: ClientError
-  message: Timeout exceeded
+- true
 ...
 --
 -- Do not send multiple requests during timeout - it brokes long

--- a/test/router/retry_reads.test.lua
+++ b/test/router/retry_reads.test.lua
@@ -45,7 +45,7 @@ fiber.time() - start < 1
 util.portable_error(e)
 
 _, e = rs1:callro('sleep', {1}, {timeout = 0.0001})
-util.portable_error(e)
+util.is_timeout_error(e)
 
 --
 -- Do not send multiple requests during timeout - it brokes long

--- a/test/router/router.result
+++ b/test/router/router.result
@@ -761,7 +761,7 @@ i, res = func(iter, i)
 i, res = func(iter, i)
 ---
 ...
-assert(not i and res.code == box.error.TIMEOUT)
+assert(not i and util.is_timeout_error(res))
 ---
 - true
 ...
@@ -772,7 +772,7 @@ assert(type(res) == 'table')
 res, err = future:wait_result(0.001)
 ---
 ...
-assert(not res and err.code == box.error.TIMEOUT)
+assert(not res and util.is_timeout_error(err))
 ---
 - true
 ...

--- a/test/router/router.test.lua
+++ b/test/router/router.test.lua
@@ -273,11 +273,11 @@ assert(res == 10)
 func, iter, i = future:pairs(0.001)
 i, res = func(iter, i)
 i, res = func(iter, i)
-assert(not i and res.code == box.error.TIMEOUT)
+assert(not i and util.is_timeout_error(res))
 assert(type(res) == 'table')
 
 res, err = future:wait_result(0.001)
-assert(not res and err.code == box.error.TIMEOUT)
+assert(not res and util.is_timeout_error(err))
 assert(type(err) == 'table')
 
 test_run:switch('storage_1_a')

--- a/test/router/sync.result
+++ b/test/router/sync.result
@@ -56,10 +56,9 @@ util.portable_error(err)
 res, err = vshard.router.sync(0)
 ---
 ...
-util.portable_error(err)
+util.is_timeout_error(err)
 ---
-- type: ClientError
-  message: Timeout exceeded
+- true
 ...
 --
 -- gh-190: router should not ignore cfg.sync_timeout.

--- a/test/router/sync.test.lua
+++ b/test/router/sync.test.lua
@@ -18,7 +18,7 @@ vshard.router.bootstrap()
 res, err = vshard.router.sync(-1)
 util.portable_error(err)
 res, err = vshard.router.sync(0)
-util.portable_error(err)
+util.is_timeout_error(err)
 
 --
 -- gh-190: router should not ignore cfg.sync_timeout.

--- a/test/storage/ref.result
+++ b/test/storage/ref.result
@@ -126,9 +126,9 @@ ok, err = vshard.storage.bucket_send(1501, util.replicasets[1],                 
                                      {timeout = timeout})
  | ---
  | ...
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
  | ---
- | - Timeout exceeded
+ | - true
  | ...
 
 --
@@ -181,9 +181,9 @@ _ = fiber.create(vshard.storage.bucket_send, 1, util.replicasets[2],            
 ok, err = lref.add(rid, sid, small_timeout)
  | ---
  | ...
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
  | ---
- | - Timeout exceeded
+ | - true
  | ...
 -- Ref will wait if timeout is big enough.
 ok, err = nil

--- a/test/storage/ref.test.lua
+++ b/test/storage/ref.test.lua
@@ -53,7 +53,7 @@ big_timeout = 1000000
 timeout = 0.01
 ok, err = vshard.storage.bucket_send(1501, util.replicasets[1],                 \
                                      {timeout = timeout})
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
 
 --
 -- After unref all the bucket moves are allowed again.
@@ -78,7 +78,7 @@ fiber = require('fiber')
 _ = fiber.create(vshard.storage.bucket_send, 1, util.replicasets[2],            \
                  {timeout = big_timeout})
 ok, err = lref.add(rid, sid, small_timeout)
-assert(not ok and err.message)
+assert(not ok and util.is_timeout_error(err))
 -- Ref will wait if timeout is big enough.
 ok, err = nil
 _ = fiber.create(function()                                                     \


### PR DESCRIPTION
Issue https://github.com/tarantool/tarantool/issues/6144 suggests changing the exception thrown on
time-out error, which requires changing the tests in this repository to
tests that will run on both types of exception thrown.