### PR TITLE
Use `msgpack_iterator:take_array()` method

### DIFF
--- a/test/router-luatest/router_test.lua
+++ b/test/router-luatest/router_test.lua
@@ -186,9 +186,9 @@ g.test_map_callrw_raw = function(g)
     t.run_only_if(vutil.feature.netbox_return_raw)
 
     local create_map_func_f = function(res1)
-        _G.do_map = function(res2)
+        rawset(_G, 'do_map', function(res2)
             return {res1, res2}
-        end
+        end)
     end
     g.replica_1_a:exec(create_map_func_f, {1})
     g.replica_2_a:exec(create_map_func_f, {2})

--- a/vshard/router/init.lua
+++ b/vshard/router/init.lua
@@ -599,12 +599,7 @@ local function router_call_impl(router, bucket_id, mode, prefer_replica,
                 -- When no values, nil is not packed into msgpack object. Same
                 -- as in raw netbox.
                 if count > 1 then
-                    count = count - 1
-                    local res = table_new(count, 0)
-                    for i = 1, count do
-                        res[i] = it:take()
-                    end
-                    call_status = msgpack_object(res)
+                    call_status = it:take_array(count - 1)
                 end
                 call_error = nil
             end
@@ -869,10 +864,7 @@ local function router_map_callrw(router, func, args, opts)
                 goto fail
             end
             if count > 1 then
-                -- XXX: msgpack object API doesn't allow to wrap tail of its
-                -- iterator into an array. Which probably renders this feature
-                -- not very useful here for small- and middle-sized responses.
-                map[uuid] = msgpack_object({res:take()})
+                map[uuid] = res:take_array(count - 1)
             end
             timeout = deadline - fiber_clock()
         end


### PR DESCRIPTION
The patchset makes the router use `take_array()` method of msgpack iterator instead of manual tail cut via an intermediate Lua table.