### PR TITLE
ci: stabilise test runs (auto-rerun tests after failure)

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -45,3 +45,5 @@ jobs:
 
       - run: cmake .
       - run: make test-force
+        env:
+          TEST_RUN_RETRIES: 3

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -39,3 +39,5 @@ jobs:
 
       - run: cmake .
       - run: make test-force
+        env:
+          TEST_RUN_RETRIES: 3

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,12 +3,12 @@ if(POLICY CMP0037)
 endif(POLICY CMP0037)
 
 add_custom_target(test
-    COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j -1
+    COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j
         --builddir=${PROJECT_BINARY_DIR}
         --vardir=${PROJECT_BINARY_DIR}/test/var)
 
 add_custom_target(test-force
-    COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j -1
+    COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j
         --builddir=${PROJECT_BINARY_DIR}
         --vardir=${PROJECT_BINARY_DIR}/test/var
         --force)


### PR DESCRIPTION
- Bump test-run to newest version which has the facility to auto-rerun tests
- Run tests in parallel mode (auto-rerun is implemented only in this mode)
- Pass TEST_RUN_RETRIES=3 to environment to auto-rerun tests (by default, tests are not rerun automatically)