### PR TITLE
SSL and multilisten support

### DIFF
--- a/test/instances/storage.lua
+++ b/test/instances/storage.lua
@@ -1,5 +1,11 @@
 #!/usr/bin/env tarantool
 local helpers = require('test.luatest_helpers')
+
+--
+-- Commonly used libraries.
+--
+_G.fiber = require('fiber')
+
 -- Do not load entire vshard into the global namespace to catch errors when code
 -- relies on that.
 _G.vshard = {
@@ -12,6 +18,7 @@ if box.ctl.set_on_shutdown_timeout then
 end
 
 box.cfg(helpers.box_cfg())
+local instance_uuid = box.info.uuid
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
 
 local function box_error()
@@ -22,7 +29,23 @@ local function echo(...)
     return ...
 end
 
+local function get_uuid()
+    return instance_uuid
+end
+
+local function session_set(key, value)
+    box.session.storage[key] = value
+    return true
+end
+
+local function session_get(key)
+    return box.session.storage[key]
+end
+
 _G.box_error = box_error
 _G.echo = echo
+_G.get_uuid = get_uuid
+_G.session_set = session_set
+_G.session_get = session_get
 
 _G.ready = true

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -160,6 +160,21 @@ function Server:instance_uuid()
     return uuid
 end
 
+function Server:replicaset_uuid()
+    -- Cache the value when found it first time.
+    if self.replicaset_uuid_value then
+        return self.replicaset_uuid_value
+    end
+    local uuid = self:exec(function() return box.info.cluster.uuid end)
+    if uuid == nil then
+        -- Probably didn't bootstrap yet. Listen starts before replicaset UUID
+        -- is assigned.
+        return nil
+    end
+    self.replicaset_uuid_value = uuid
+    return uuid
+end
+
 -- TODO: Add the 'wait_for_readiness' parameter for the restart()
 -- method.
 
@@ -192,6 +207,7 @@ function Server:cleanup()
     end
     self.instance_id_value = nil
     self.instance_uuid_value = nil
+    self.replicaset_uuid_value = nil
 end
 
 function Server:drop()

--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -21,13 +21,9 @@ end
 local function config_new(templ)
     local res = table.deepcopy(templ)
     local sharding = {}
-    local meta = {replicasets = {}}
     res.sharding = sharding
     for i, replicaset_templ in pairs(templ.sharding) do
         local replicaset_uuid = uuid_next()
-        meta.replicasets[i] = {
-            uuid = replicaset_uuid
-        }
         local replicas = {}
         local replicaset = table.deepcopy(replicaset_templ)
         replicaset.replicas = replicas
@@ -40,7 +36,7 @@ local function config_new(templ)
         end
         sharding[replicaset_uuid] = replicaset
     end
-    return res, meta
+    return res
 end
 
 --

--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -1,7 +1,18 @@
+local t = require('luatest')
 local helpers = require('test.luatest_helpers')
 local cluster = require('test.luatest_helpers.cluster')
+local vconst = require('vshard.consts')
 
 local uuid_idx = 1
+--
+-- The maps help to preserve the same UUID for replicas and replicasets during
+-- reconfiguration. Reconfig means an update of a cfg template which doesn't
+-- contain UUIDs + generation of a new real cfg to apply on nodes. The real cfg
+-- needs to have same UUIDs for the nodes used in the old versions of the
+-- template.
+--
+local replica_name_to_uuid_map = {}
+local replicaset_name_to_uuid_map = {}
 
 --
 -- New UUID unique per this process. Generation is not random - for simplicity
@@ -14,6 +25,23 @@ local function uuid_next()
     return '00000000-0000-0000-0000-'..string.rep('0', 12 - #last)..last
 end
 
+local function name_to_uuid(map, name)
+    local res = map[name]
+    if not res then
+        res = uuid_next()
+        map[name] = res
+    end
+    return res
+end
+
+local function replica_name_to_uuid(name)
+    return name_to_uuid(replica_name_to_uuid_map, name)
+end
+
+local function replicaset_name_to_uuid(name)
+    return name_to_uuid(replicaset_name_to_uuid_map, name)
+end
+
 --
 -- Build a valid vshard config by a template. A template does not specify
 -- anything volatile such as URIs, UUIDs - these are installed at runtime.
@@ -22,16 +50,33 @@ local function config_new(templ)
     local res = table.deepcopy(templ)
     local sharding = {}
     res.sharding = sharding
+    -- Is supposed to intensify reconnects when replication and listen URIs
+    -- change.
+    res.replication_timeout = 0.1
     for i, replicaset_templ in pairs(templ.sharding) do
-        local replicaset_uuid = uuid_next()
+        local replicaset_uuid = replicaset_name_to_uuid(i)
         local replicas = {}
         local replicaset = table.deepcopy(replicaset_templ)
         replicaset.replicas = replicas
         for replica_name, replica_templ in pairs(replicaset_templ.replicas) do
-            local replica_uuid = uuid_next()
+            local replica_uuid = replica_name_to_uuid(replica_name)
             local replica = table.deepcopy(replica_templ)
+            replica.port_uri = nil
+            replica.port_count = nil
             replica.name = replica_name
-            replica.uri = 'storage:storage@'..helpers.instance_uri(replica_name)
+
+            local port_count = replica_templ.port_count
+            local creds = 'storage:storage@'
+            if port_count == nil then
+                replica.uri = creds..helpers.instance_uri(replica_name)
+            else
+                local listen = table.new(port_count, 0)
+                for i = 1, port_count do
+                    listen[i] = creds..helpers.instance_uri(replica_name..i)
+                end
+                replica.listen = listen
+                replica.uri = listen[replica_templ.port_uri]
+            end
             replicas[replica_uuid] = replica
         end
         sharding[replicaset_uuid] = replicaset
@@ -73,6 +118,11 @@ local function storage_new(g, cfg)
                 box_cfg = box_cfg,
             }, 'storage.lua')
             g[name] = server
+            -- VShard specific details to use in various helper functions.
+            server.vtest = {
+                name = name,
+                is_storage = true,
+            }
             g.cluster:add_server(server)
 
             table.insert(all_servers, server)
@@ -110,6 +160,59 @@ local function storage_new(g, cfg)
 end
 
 --
+-- Apply the config to all vshard storages in the cluster.
+--
+local function storage_cfg(g, cfg)
+    -- No support yet for dynamic node addition and removal. Only reconfig.
+    local fids = {}
+    local storages = {}
+    -- Map-reduce. It should make reconfig not only faster but also not depend
+    -- on which order would be non-blocking. For example, there might be a
+    -- config which makes the master hang until some replica is configured
+    -- first. When all are done in parallel, it won't matter.
+    for _, storage in pairs(g.cluster.servers) do
+        if storage.vtest and storage.vtest.is_storage then
+            table.insert(storages, storage)
+            table.insert(fids, storage:exec(function(cfg)
+                local f = fiber.new(vshard.storage.cfg, cfg, box.info.uuid)
+                f:set_joinable(true)
+                return f:id()
+            end, {cfg}))
+        end
+    end
+    local errors = {}
+    for i, storage in pairs(storages) do
+        local ok, err = storage:exec(function(fid)
+            return fiber.find(fid):join()
+        end, {fids[i]})
+        if not ok then
+            errors[storage.vtest.name] = err
+        end
+    end
+    t.assert_equals(errors, {}, 'storage reconfig')
+end
+
+--
+-- Find first active bucket on the storage. In tests it helps not to assume
+-- where the buckets are located by hardcoded numbers and uuids.
+--
+local function storage_first_bucket(storage)
+    return storage:exec(function(status)
+        local res = box.space._bucket.index.status:min(status)
+        return res ~= nil and res.id or nil
+    end, {vconst.BUCKET.ACTIVE})
+end
+
+--
+-- Apply the config on the given router.
+--
+local function router_cfg(router, cfg)
+    router:exec(function(cfg)
+        vshard.router.cfg(cfg)
+    end, {cfg})
+end
+
+--
 -- Create a new router in the cluster.
 --
 local function router_new(g, name, cfg)
@@ -122,14 +225,33 @@ local function router_new(g, name, cfg)
     g[name] = server
     g.cluster:add_server(server)
     server:start()
-    server:exec(function(cfg)
-        vshard.router.cfg(cfg)
-    end, {cfg})
+    router_cfg(server, cfg)
     return server
+end
+
+--
+-- Disconnect the router from all storages.
+--
+local function router_disconnect(router)
+    router:exec(function()
+        local replicasets = vshard.router.static.replicasets
+        for _, rs in pairs(replicasets) do
+            for _, r in pairs(rs.replicas) do
+                local c = r.conn
+                if c then
+                    c:close()
+                end
+            end
+        end
+    end)
 end
 
 return {
     config_new = config_new,
     storage_new = storage_new,
+    storage_cfg = storage_cfg,
+    storage_first_bucket = storage_first_bucket,
     router_new = router_new,
+    router_cfg = router_cfg,
+    router_disconnect = router_disconnect,
 }

--- a/test/router-luatest/router_test.lua
+++ b/test/router-luatest/router_test.lua
@@ -4,7 +4,7 @@ local vutil = require('vshard.util')
 local wait_timeout = 120
 
 local g = t.group('router')
-local cluster_cfg, cfg_meta = vtest.config_new({
+local cluster_cfg = vtest.config_new({
     sharding = {
         {
             replicas = {
@@ -206,9 +206,11 @@ g.test_map_callrw_raw = function(g)
             err = err,
         }
     end, {wait_timeout})
+    local rs1_uuid = g.replica_1_a:replicaset_uuid()
+    local rs2_uuid = g.replica_2_a:replicaset_uuid()
     local expected = {
-        [cfg_meta.replicasets[1].uuid] = {{1, 3}},
-        [cfg_meta.replicasets[2].uuid] = {{2, 3}},
+        [rs1_uuid] = {{1, 3}},
+        [rs2_uuid] = {{2, 3}},
     }
     t.assert_equals(res.val, expected, 'map callrw success')
     t.assert_equals(res.map_type, 'userdata', 'values are msgpacks')
@@ -226,7 +228,7 @@ g.test_map_callrw_raw = function(g)
                                         return_raw = true})
     end, {wait_timeout})
     expected = {
-        [cfg_meta.replicasets[1].uuid] = {{1}},
+        [rs1_uuid] = {{1}},
     }
     t.assert_equals(res, expected, 'map callrw without one value success')
     --
@@ -248,7 +250,7 @@ g.test_map_callrw_raw = function(g)
         type = 'ClientError',
         message = 'map_err'
     }, 'error object')
-    t.assert_equals(err_uuid, cfg_meta.replicasets[2].uuid, 'error uuid')
+    t.assert_equals(err_uuid, rs2_uuid, 'error uuid')
     --
     -- Cleanup.
     --

--- a/test/storage/recovery_errinj.result
+++ b/test/storage/recovery_errinj.result
@@ -56,10 +56,10 @@ _bucket:replace{1, vshard.consts.BUCKET.ACTIVE, util.replicasets[2]}
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
 ---
 ...
-ret, err.code
+ret, util.is_timeout_error(err)
 ---
 - null
-- 78
+- true
 ...
 _bucket = box.space._bucket
 ---

--- a/test/storage/recovery_errinj.test.lua
+++ b/test/storage/recovery_errinj.test.lua
@@ -23,7 +23,7 @@ vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
 _bucket = box.space._bucket
 _bucket:replace{1, vshard.consts.BUCKET.ACTIVE, util.replicasets[2]}
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
-ret, err.code
+ret, util.is_timeout_error(err)
 _bucket = box.space._bucket
 _bucket:get{1}
 

--- a/test/unit-luatest/config_test.lua
+++ b/test/unit-luatest/config_test.lua
@@ -1,0 +1,55 @@
+local t = require('luatest')
+local vcfg = require('vshard.cfg')
+local vutil = require('vshard.util')
+local luuid = require('uuid')
+
+local g = t.group('config')
+
+g.test_basic_uri = function()
+    local url = 'storage:storage@127.0.0.1:3301'
+    local storage_1_a = {
+        uri = url,
+        name = 'storage_1_a',
+    }
+    local config = {
+        sharding = {
+            storage_1_uuid = {
+                replicas = {
+                    storage_1_a_uuid = storage_1_a,
+                }
+            },
+        },
+    }
+    t.assert(vcfg.check(config), 'normal uri')
+
+    if vutil.feature.multilisten then
+        storage_1_a.uri = {url}
+        t.assert(vcfg.check(config), 'table uri')
+
+        storage_1_a.uri = {url, params = {transport = 'plain'}}
+        t.assert(vcfg.check(config), 'uri with options')
+    else
+        storage_1_a.uri = {url}
+        t.assert_error(vcfg.check, config)
+
+        storage_1_a.uri = {url, params = {transport = 'plain'}}
+        t.assert_error(vcfg.check, config)
+    end
+    storage_1_a.uri = 3301
+    t.assert(vcfg.check(config), 'number uri')
+
+    storage_1_a.uri = 'bad uri ###'
+    t.assert_error(vcfg.check, config)
+
+    storage_1_a.uri = ''
+    t.assert_error(vcfg.check, config)
+
+    storage_1_a.uri = {}
+    t.assert_error(vcfg.check, config)
+
+    storage_1_a.uri = nil
+    t.assert_error(vcfg.check, config)
+
+    storage_1_a.uri = luuid.new()
+    t.assert_error(vcfg.check, config)
+end

--- a/test/unit-luatest/util_test.lua
+++ b/test/unit-luatest/util_test.lua
@@ -1,0 +1,97 @@
+local t = require('luatest')
+local luuid = require('uuid')
+local vutil = require('vshard.util')
+
+local g = t.group('util')
+
+g.test_uri_eq = function()
+    local uri_eq = vutil.uri_eq
+    --
+    -- Equal.
+    --
+    t.assert(uri_eq(1, 1))
+    t.assert(uri_eq('1', '1'))
+    t.assert(uri_eq(1, '1'))
+    t.assert(uri_eq('1', 1))
+
+    --
+    -- Not equal.
+    --
+    t.assert(not uri_eq(1, 2))
+    t.assert(not uri_eq('1', '2'))
+    t.assert(not uri_eq(1, '2'))
+    t.assert(not uri_eq('1', 2))
+
+    if not vutil.feature.multilisten then
+        return
+    end
+
+    --
+    -- Equal.
+    --
+    t.assert(uri_eq({1}, 1))
+    t.assert(uri_eq(1, {1}))
+    t.assert(uri_eq('1', {'1'}))
+    t.assert(uri_eq({'1'}, '1'))
+    t.assert(uri_eq({'1'}, {'1'}))
+    t.assert(uri_eq({1}, {1}))
+
+    t.assert(uri_eq({'1'}, 1))
+    t.assert(uri_eq('1', {1}))
+    t.assert(uri_eq({1}, '1'))
+    t.assert(uri_eq(1, {'1'}))
+    t.assert(uri_eq({1}, {'1'}))
+    t.assert(uri_eq({'1'}, {1}))
+
+    t.assert(uri_eq({
+        1, params = {key1 = 10, key2 = 20}
+    }, {
+        1, params = {key1 = 10, key2 = 20}
+    }))
+
+    t.assert(uri_eq({
+        '1', params = {key1 = 10, key2 = '20'}
+    }, {
+        1, params = {key1 = 10, key2 = 20}
+    }))
+
+    t.assert(uri_eq({
+        1, params = {key1 = {'10', 20}, key2 = 30}
+    }, {
+        '1', params = {key1 = {10, 20}, key2 = 30}
+    }))
+
+    t.assert(uri_eq(
+        'localhost:1?key1=10&key1=20&key2=30',
+        {'localhost:1', params = {key1 = {10, 20}, key2 = 30}}
+    ))
+
+    --
+    -- Not equal.
+    --
+    t.assert(not uri_eq({
+        1, params = {key1 = 10, key2 = 20}
+    }, {
+        1, params = {key1 = 20, key2 = 10}
+    }))
+
+    t.assert(not uri_eq({
+        '1', params = {key1 = 10}
+    }, {
+        1, params = {key1 = 10, key2 = 20}
+    }))
+
+    t.assert(not uri_eq({
+        1, params = {key1 = {10}, key2 = 30}
+    }, {
+        1, params = {key1 = {10, 20}, key2 = 30}
+    }))
+
+    t.assert(not uri_eq(
+        'localhost:1?key1=10&key1=20&key2=30',
+        {'localhost:1', params = {key1 = {20, 10}, key2 = 30}}
+    ))
+
+    t.assert_error(uri_eq, 1, luuid.new())
+    t.assert_error(uri_eq, nil, 1)
+end

--- a/test/unit/config.result
+++ b/test/unit/config.result
@@ -462,9 +462,9 @@ lcfg.check(cfg)['sharding']
 - replicaset_uuid:
     replicas:
       replica_uuid:
+        master: true
         uri: 127.0.0.1
         name: storage
-        master: true
     weight: 100000
 ...
 replica.uri = 'user:password@localhost'
@@ -475,9 +475,9 @@ lcfg.check(cfg)['sharding']
 - replicaset_uuid:
     replicas:
       replica_uuid:
+        master: true
         uri: user:password@localhost
         name: storage
-        master: true
     weight: 100000
 ...
 replica.url = old_uri

--- a/test/unit/config.result
+++ b/test/unit/config.result
@@ -31,28 +31,13 @@ check({sharding = {100}})
 ---
 - Replicaset must be a table
 ...
-replica = {}
+replica = {uri = 'uri:uri@uri'}
 ---
 ...
 replicaset = {replicas = {['replica_uuid'] = replica}}
 ---
 ...
 cfg = {sharding = {['replicaset_uuid'] = replicaset}}
----
-...
--- URI is not string.
-check(cfg)
----
-- URI must be specified
-...
-replica.uri = 100
----
-...
-check(cfg)
----
-- URI must be non-empty string
-...
-replica.uri = 'uri:uri@uri'
 ---
 ...
 -- Name is not string.
@@ -467,7 +452,7 @@ replica.uri = 'invalid uri'
 ...
 util.check_error(lcfg.check, cfg)
 ---
-- 'Invalid URI: invalid uri'
+- Invalid URI
 ...
 replica.uri = '127.0.0.1'
 ---

--- a/test/unit/config.test.lua
+++ b/test/unit/config.test.lua
@@ -18,15 +18,9 @@ check({sharding = 100})
 -- Replicaset is not table.
 check({sharding = {100}})
 
-replica = {}
+replica = {uri = 'uri:uri@uri'}
 replicaset = {replicas = {['replica_uuid'] = replica}}
 cfg = {sharding = {['replicaset_uuid'] = replicaset}}
-
--- URI is not string.
-check(cfg)
-replica.uri = 100
-check(cfg)
-replica.uri = 'uri:uri@uri'
 
 -- Name is not string.
 replica.name = 100

--- a/vshard/cfg.lua
+++ b/vshard/cfg.lua
@@ -5,7 +5,7 @@ local luri = require('uri')
 local lutil = require('vshard.util')
 local consts = require('vshard.consts')
 
-local function check_uri(uri)
+local function check_uri_connect(uri)
     if not lutil.feature.multilisten then
         if type(uri) == 'number' then
             uri = tostring(uri)
@@ -15,6 +15,16 @@ local function check_uri(uri)
     end
     if not luri.parse(uri) then
         error('Invalid URI')
+    end
+end
+
+local function check_uri_listen(uri)
+    if not lutil.feature.multilisten then
+        error('Listen URIs are not supported at this version')
+    end
+    if not luri.parse_many(uri) then
+       error('URI must be a non-empty string, or a number, or a table, or an '..
+             'array of these types')
     end
 end
 
@@ -124,7 +134,13 @@ local replica_template = {
     uri = {
         type = {'non-empty string', 'number', 'table'},
         name = 'URI',
-        check = check_uri
+        check = check_uri_connect
+    },
+    listen = {
+        type = {'non-empty string', 'number', 'table'},
+        name = 'listen',
+        check = check_uri_listen,
+        is_optional = true,
     },
     name = {type = 'string', name = "Name", is_optional = true},
     zone = {type = {'string', 'number'}, name = "Zone", is_optional = true},

--- a/vshard/cfg.lua
+++ b/vshard/cfg.lua
@@ -2,11 +2,19 @@
 
 local log = require('log')
 local luri = require('uri')
+local lutil = require('vshard.util')
 local consts = require('vshard.consts')
 
 local function check_uri(uri)
+    if not lutil.feature.multilisten then
+        if type(uri) == 'number' then
+            uri = tostring(uri)
+        elseif type(uri) ~= 'string' then
+            error('Only number and string URI are supported at this version')
+        end
+    end
     if not luri.parse(uri) then
-        error('Invalid URI: ' .. uri)
+        error('Invalid URI')
     end
 end
 
@@ -113,7 +121,11 @@ local function validate_config(config, template, check_arg)
 end
 
 local replica_template = {
-    uri = {type = 'non-empty string', name = 'URI', check = check_uri},
+    uri = {
+        type = {'non-empty string', 'number', 'table'},
+        name = 'URI',
+        check = check_uri
+    },
     name = {type = 'string', name = "Name", is_optional = true},
     zone = {type = {'string', 'number'}, name = "Zone", is_optional = true},
     master = {

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -4,7 +4,7 @@
 -- <replicaset> = {
 --     replicas = {
 --         [replica_uuid] = {
---             uri = string,
+--             uri = URI,
 --             name = string,
 --             uuid = string,
 --             conn = <netbox> + .replica + .replicaset,

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -631,7 +631,7 @@ local function rebind_replicasets(replicasets, old_replicasets)
         for replica_uuid, replica in pairs(replicaset.replicas) do
             local old_replica = old_replicaset and
                                 old_replicaset.replicas[replica_uuid]
-            if old_replica and old_replica.uri == replica.uri then
+            if old_replica and util.uri_eq(old_replica.uri, replica.uri) then
                 local conn = old_replica.conn
                 replica.conn = conn
                 replica.down_ts = old_replica.down_ts

--- a/vshard/router/init.lua
+++ b/vshard/router/init.lua
@@ -24,15 +24,11 @@ local util = require('vshard.util')
 local seq_serializer = { __serialize = 'seq' }
 
 local msgpack_is_object = lmsgpack.is_object
-local msgpack_object = lmsgpack.object
 
 if not util.feature.msgpack_object then
     local msg = 'Msgpack object feature is not supported by current '..
                 'Tarantool version'
     msgpack_is_object = function()
-        error(msg)
-    end
-    msgpack_object = function()
         error(msg)
     end
 end

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -2692,7 +2692,15 @@ local function storage_cfg(cfg, this_replica_uuid, is_reload)
         --
         -- If a master role of the replica is not changed, then
         -- 'read_only' can be set right here.
-        box_cfg.listen = box_cfg.listen or this_replica.uri
+        local this_replicaset_cfg = vshard_cfg.sharding[this_replicaset.uuid]
+        local this_replica_cfg = this_replicaset_cfg.replicas[this_replica.uuid]
+
+        if box_cfg.listen == nil then
+            box_cfg.listen = this_replica_cfg.listen
+            if box_cfg.listen == nil then
+                box_cfg.listen = this_replica_cfg.uri
+            end
+        end
         if not box_cfg.replication then
             box_cfg.replication = {}
             for _, replica in pairs(this_replicaset.replicas) do

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -4,6 +4,7 @@ local fiber = require('fiber')
 local lerror = require('vshard.error')
 local lversion = require('vshard.version')
 local lmsgpack = require('msgpack')
+local luri = require('uri')
 
 local MODULE_INTERNALS = '__module_vshard_util'
 local M = rawget(_G, MODULE_INTERNALS)
@@ -238,6 +239,7 @@ end
 local feature = {
     msgpack_object = lmsgpack.object ~= nil,
     netbox_return_raw = version_is_at_least(2, 10, 0, 'beta', 2, 86),
+    multilisten = luri.parse_many ~= nil,
 }
 
 return {


### PR DESCRIPTION
The patchset allows to use multilisten and SSL features. Although there was a way to use multilisten before (as long as the URIs were strings and `listen` was passed to each storage in the root of its vhsard config), it is now easier.