### PR TITLE
Transfer bucket tuples as is without re-coding via Lua

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,6 +30,8 @@ local test_rules = {
         '113/imsgpack',
         '113/ivconst',
         '113/ivshard',
+        '113/ivtest',
+        '113/ivutil',
     }
 }
 

--- a/test/instances/storage.lua
+++ b/test/instances/storage.lua
@@ -8,7 +8,10 @@ local helpers = require('test.luatest_helpers')
 --
 _G.ifiber = require('fiber')
 _G.ilt = require('luatest')
+_G.imsgpack = require('msgpack')
 _G.ivconst = require('vshard.consts')
+_G.ivutil = require('vshard.util')
+_G.ivtest = require('test.luatest_helpers.vtest')
 
 -- Do not load entire vshard into the global namespace to catch errors when code
 -- relies on that.

--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -2,6 +2,7 @@ local t = require('luatest')
 local helpers = require('test.luatest_helpers')
 local cluster = require('test.luatest_helpers.cluster')
 local fiber = require('fiber')
+local uuid = require('uuid')
 local vrepset = require('vshard.replicaset')
 
 local uuid_idx = 1
@@ -15,21 +16,30 @@ local uuid_idx = 1
 local replica_name_to_uuid_map = {}
 local replicaset_name_to_uuid_map = {}
 
+local function uuid_str_from_int(i)
+    i = tostring(i)
+    assert(#i <= 12)
+    return '00000000-0000-0000-0000-'..string.rep('0', 12 - #i)..i
+end
+
+local function uuid_from_int(i)
+    return uuid.fromstr(uuid_str_from_int(i))
+end
+
 --
 -- New UUID unique per this process. Generation is not random - for simplicity
 -- and reproducibility.
 --
-local function uuid_next()
-    local last = tostring(uuid_idx)
+local function uuid_str_next()
+    local i = uuid_idx
     uuid_idx = uuid_idx + 1
-    assert(#last <= 12)
-    return '00000000-0000-0000-0000-'..string.rep('0', 12 - #last)..last
+    return uuid_str_from_int(i)
 end
 
 local function name_to_uuid(map, name)
     local res = map[name]
     if not res then
-        res = uuid_next()
+        res = uuid_str_next()
         map[name] = res
     end
     return res
@@ -452,4 +462,5 @@ return {
     router_new = router_new,
     router_cfg = router_cfg,
     router_disconnect = router_disconnect,
+    uuid_from_int = uuid_from_int,
 }

--- a/test/storage-luatest/storage_1_1_test.lua
+++ b/test/storage-luatest/storage_1_1_test.lua
@@ -1,0 +1,160 @@
+local t = require('luatest')
+local vtest = require('test.luatest_helpers.vtest')
+local vutil = require('vshard.util')
+local wait_timeout = 120
+
+local group_config = {{engine = 'memtx'}, {engine = 'vinyl'}}
+
+if vutil.feature.memtx_mvcc then
+    table.insert(group_config, {
+        engine = 'memtx', memtx_use_mvcc_engine = true
+    })
+    table.insert(group_config, {
+        engine = 'vinyl', memtx_use_mvcc_engine = true
+    })
+end
+
+local test_group = t.group('storage', group_config)
+
+local cfg_template = {
+    sharding = {
+        {
+            replicas = {
+                replica_1_a = {
+                    master = true,
+                },
+            },
+        },
+        {
+            replicas = {
+                replica_2_a = {
+                    master = true,
+                },
+            },
+        },
+    },
+    bucket_count = 10
+}
+local cluster_cfg
+
+test_group.before_all(function(g)
+    cfg_template.memtx_use_mvcc_engine = g.params.memtx_use_mvcc_engine
+    cluster_cfg = vtest.config_new(cfg_template)
+
+    vtest.storage_new(g, cluster_cfg)
+    vtest.storage_bootstrap(g, cluster_cfg)
+    vtest.storage_rebalancer_disable(g)
+end)
+
+test_group.after_all(function(g)
+    g.cluster:drop()
+end)
+
+--
+-- Test how bucket_send preserves tuple field types over the network (gh-327).
+--
+test_group.test_bucket_send_field_types = function(g)
+    -- Make a space with all the field types whose msgpack representation is
+    -- nontrivial.
+    local _, err = vtest.storage_exec_each_master(g, function(engine)
+        local format = {
+            {'id', 'unsigned'},
+            {'bid', 'unsigned'},
+        }
+        local i = 1
+        local tuple = {i, box.NULL}
+        -- Decimal appeared earlier, but this is when it can be used as a field
+        -- type. Same logic with other types.
+        if ivutil.version_is_at_least(2, 3, 0, nil, 0, 0) then
+            ivutil.table_extend(format, {
+                {'fdecimal', 'decimal'},
+            })
+            i = i + 1
+            table.insert(tuple, require('decimal').new(i))
+        end
+        if ivutil.version_is_at_least(2, 4, 0, nil, 0, 0) then
+            ivutil.table_extend(format, {
+                {'fuuid', 'uuid'},
+            })
+            i = i + 1
+            table.insert(tuple, ivtest.uuid_from_int(i))
+        end
+        if ivutil.version_is_at_least(2, 10, 0, nil, 0, 0) then
+            ivutil.table_extend(format, {
+                {'fdatetime', 'datetime'},
+                {'finterval', 'interval'},
+                {'fdouble', 'double'},
+                {'fbinary', 'varbinary'},
+            })
+            local dt = require('datetime')
+            i = i + 1
+            table.insert(tuple, dt.new({year = i}))
+            i = i + 1
+            table.insert(tuple, dt.interval.new({year = i}))
+            i = i + 1
+            table.insert(tuple, require('ffi').cast('double', i))
+            -- That is the simplest way to get an MP_BIN in Lua without FFI.
+            i = i + 1
+            local value = box.execute([[SELECT CAST(? AS VARBINARY)]],
+                                      {tostring(i)}).rows[1]
+            value = imsgpack.object(value):iterator()
+            -- Skip tuple's MP_ARRAY header.
+            value:decode_array_header()
+            -- Get first and only field - MP_BIN.
+            table.insert(tuple, value:take())
+        end
+        local s = box.schema.create_space('test', {
+            engine = engine,
+            format = format,
+        })
+        s:create_index('pk')
+        s:create_index('bucket_id', {unique = false, parts = {2}})
+        rawset(_G, 'test_tuple', tuple)
+    end, {g.params.engine})
+    t.assert_equals(err, nil, 'space creation no error')
+
+    -- Send the bucket with a complicated tuple.
+    local bid = g.replica_1_a:exec(function(timeout, dst)
+        local bid = _G.get_first_bucket()
+        local tuple = _G.test_tuple
+        tuple[2] = bid
+        box.space.test:replace(tuple)
+        local ok, err = ivshard.storage.bucket_send(bid, dst,
+                                                    {timeout = timeout})
+        ilt.assert_equals(err, nil, 'bucket_send no error')
+        ilt.assert(ok, 'bucket_send ok')
+        return bid
+    end, {wait_timeout, g.replica_2_a:replicaset_uuid()})
+
+    -- Ensure the tuple is delivered as is and fits into the space's format.
+    g.replica_2_a:exec(function(bid)
+        local src_tuple = _G.test_tuple
+        src_tuple[2] = bid
+        local dst_tuple = box.space.test:get{src_tuple[1]}
+        -- Comparison unfortunately can only be done in Lua. Msgpack objects are
+        -- incomparable which means the original MP_BIN wouldn't be equal to
+        -- anything. But that should be safe anyway if the tuple managed to fit
+        -- into the space.
+        dst_tuple = dst_tuple:totable()
+        src_tuple = box.tuple.new(src_tuple):totable()
+        ilt.assert_equals(dst_tuple, src_tuple, 'tuple is delivered as is')
+    end, {bid})
+
+    -- Cleanup.
+    g.replica_1_a:exec(function(timeout)
+        _G.wait_bucket_gc(timeout)
+    end, {wait_timeout})
+
+    g.replica_2_a:exec(function(bid, timeout, dst)
+        box.space.test:truncate()
+        local ok, err = ivshard.storage.bucket_send(bid, dst,
+                                                    {timeout = timeout})
+        ilt.assert_equals(err, nil, 'bucket_send no error')
+        ilt.assert(ok, 'bucket_send ok')
+        _G.wait_bucket_gc()
+    end, {bid, wait_timeout, g.replica_1_a:replicaset_uuid()})
+
+    vtest.storage_exec_each_master(g, function()
+        box.space.test:drop()
+    end)
+end

--- a/test/unit-luatest/util_test.lua
+++ b/test/unit-luatest/util_test.lua
@@ -95,3 +95,19 @@ g.test_uri_eq = function()
     t.assert_error(uri_eq, 1, luuid.new())
     t.assert_error(uri_eq, nil, 1)
 end
+
+g.test_table_extend = function()
+    local function test_extend(dst, src, res)
+        local orig_src = table.copy(src)
+        t.assert(vutil.table_extend(dst, src) == dst)
+        t.assert_equals(dst, res)
+        t.assert_equals(src, orig_src)
+    end
+    test_extend({}, {}, {})
+    test_extend({1}, {}, {1})
+    test_extend({}, {1}, {1})
+    test_extend({1, 2}, {3}, {1, 2, 3})
+    test_extend({1}, {2, 3}, {1, 2, 3})
+    test_extend({}, {1, 2, 3}, {1, 2, 3})
+    test_extend({1, 2, 3}, {}, {1, 2, 3})
+end

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -236,6 +236,14 @@ local function table_minus_yield(dst, src, interval)
     return dst
 end
 
+--
+-- Move all items of src to the end of dst. It is assumed both tables are
+-- arrays.
+--
+local function table_extend(dst, src)
+    return table.move(src, 1, #src, #dst + 1, dst)
+end
+
 local function fiber_cond_wait_xc(cond, timeout)
     -- Handle negative timeout specifically - otherwise wait() will throw an
     -- ugly usage error.
@@ -300,6 +308,7 @@ return {
     version_is_at_least = version_is_at_least,
     table_copy_yield = table_copy_yield,
     table_minus_yield = table_minus_yield,
+    table_extend = table_extend,
     fiber_cond_wait = fiber_cond_wait,
     fiber_is_self_canceled = fiber_is_self_canceled,
     feature = feature,


### PR DESCRIPTION
The patchset fixes a problem when rebalancer couldn't work if there were spaces with varbinary field type, or with double field type which stored at least one number not having a fraction. https://github.com/tarantool/vshard/issues/327