### PR TITLE
Bucket ref protection on replicas - part 1 - new fail-safe measures

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -32,6 +32,7 @@ local test_rules = {
         '113/ivshard',
         '113/ivtest',
         '113/ivutil',
+        '113/iwait_timeout',
     }
 }
 

--- a/test/instances/router.lua
+++ b/test/instances/router.lua
@@ -7,6 +7,9 @@ local helpers = require('test.luatest_helpers')
 -- same lib is declared in the _test.lua file.
 --
 _G.imsgpack = require('msgpack')
+_G.ivtest = require('test.luatest_helpers.vtest')
+_G.iwait_timeout = _G.ivtest.wait_timeout
+
 -- Do not load entire vshard into the global namespace to catch errors when code
 -- relies on that.
 _G.vshard = {

--- a/test/instances/storage.lua
+++ b/test/instances/storage.lua
@@ -11,6 +11,7 @@ _G.ilt = require('luatest')
 _G.imsgpack = require('msgpack')
 _G.ivconst = require('vshard.consts')
 _G.ivutil = require('vshard.util')
+_G.iverror = require('vshard.error')
 _G.ivtest = require('test.luatest_helpers.vtest')
 
 _G.iwait_timeout = _G.ivtest.wait_timeout
@@ -37,6 +38,15 @@ end
 box.cfg(helpers.box_cfg())
 local instance_uuid = box.info.uuid
 box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists = true})
+local local_meta = box.schema.create_space('ilocal_meta', {
+    is_local = true,
+    if_not_exists = true,
+    format = {
+        {'key', 'string'},
+        {'value', 'any', is_nullable = true}
+    }
+})
+local_meta:create_index('pk', {if_not_exists = true})
 
 local function box_error()
     box.error(box.error.PROC_LUA, 'box_error')
@@ -77,6 +87,46 @@ local function bucket_gc_wait()
     end)
 end
 
+local function bucket_gc_pause()
+    local errinj = vshard.storage.internal.errinj
+    errinj.ERRINJ_BUCKET_GC_PAUSE = true
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        if errinj.ERRINJ_BUCKET_GC_PAUSE == 1 then
+            return
+        end
+        vshard.storage.garbage_collector_wakeup()
+        error('Bucket GC is still not paused')
+    end)
+end
+
+local function bucket_gc_continue()
+    vshard.storage.internal.errinj.ERRINJ_BUCKET_GC_PAUSE = false
+    vshard.storage.garbage_collector_wakeup()
+end
+
+local function bucket_recovery_pause()
+    local errinj = vshard.storage.internal.errinj
+    errinj.ERRINJ_RECOVERY_PAUSE = true
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        if errinj.ERRINJ_RECOVERY_PAUSE == 1 then
+            return
+        end
+        vshard.storage.recovery_wakeup()
+        error('Bucket recovery is still not paused')
+    end)
+end
+
+local function bucket_recovery_continue()
+    vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
+    vshard.storage.garbage_collector_wakeup()
+end
+
+local function wal_sync()
+    -- Any WAL write guarantees that all the previous WAL writes are finished.
+    -- Local space is used so as to work on replicas too.
+    local_meta:replace{'wal_sync'}
+end
+
 _G.box_error = box_error
 _G.echo = echo
 _G.get_uuid = get_uuid
@@ -84,5 +134,10 @@ _G.get_first_bucket = get_first_bucket
 _G.session_set = session_set
 _G.session_get = session_get
 _G.bucket_gc_wait = bucket_gc_wait
+_G.bucket_gc_pause = bucket_gc_pause
+_G.bucket_gc_continue = bucket_gc_continue
+_G.bucket_recovery_pause = bucket_recovery_pause
+_G.bucket_recovery_continue = bucket_recovery_continue
+_G.wal_sync = wal_sync
 
 _G.ready = true

--- a/test/instances/storage.lua
+++ b/test/instances/storage.lua
@@ -61,7 +61,7 @@ local function session_get(key)
     return box.session.storage[key]
 end
 
-local function wait_bucket_gc(timeout)
+local function bucket_gc_wait(timeout)
     local status_index = box.space._bucket.index.status
     t.helpers.retrying({timeout = timeout}, function()
         vshard.storage.garbage_collector_wakeup()
@@ -80,6 +80,6 @@ _G.get_uuid = get_uuid
 _G.get_first_bucket = get_first_bucket
 _G.session_set = session_set
 _G.session_get = session_get
-_G.wait_bucket_gc = wait_bucket_gc
+_G.bucket_gc_wait = bucket_gc_wait
 
 _G.ready = true

--- a/test/instances/storage.lua
+++ b/test/instances/storage.lua
@@ -13,6 +13,8 @@ _G.ivconst = require('vshard.consts')
 _G.ivutil = require('vshard.util')
 _G.ivtest = require('test.luatest_helpers.vtest')
 
+_G.iwait_timeout = _G.ivtest.wait_timeout
+
 -- Do not load entire vshard into the global namespace to catch errors when code
 -- relies on that.
 _G.vshard = {
@@ -23,6 +25,7 @@ _G.ivshard = _G.vshard
 -- Get rid of luacheck warnings that _G members != variables.
 local vshard = _G.ivshard
 local vconst = _G.ivconst
+local wait_timeout = _G.iwait_timeout
 local t = _G.ilt
 
 -- Somewhy shutdown hangs on new Tarantools even though the nodes do not seem to
@@ -61,9 +64,9 @@ local function session_get(key)
     return box.session.storage[key]
 end
 
-local function bucket_gc_wait(timeout)
+local function bucket_gc_wait()
     local status_index = box.space._bucket.index.status
-    t.helpers.retrying({timeout = timeout}, function()
+    t.helpers.retrying({timeout = wait_timeout}, function()
         vshard.storage.garbage_collector_wakeup()
         if status_index:min({vconst.BUCKET.SENT}) ~= nil then
             error('Still have SENT buckets')

--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -439,8 +439,8 @@ end
 --
 -- Wait until the instance follows the master having the given instance ID.
 --
-local function storage_wait_follow_f(timeout, id)
-    local deadline = ifiber.clock() + timeout
+local function storage_wait_follow_f(id)
+    local deadline = ifiber.clock() + iwait_timeout
     local last_err
     while true do
         local info = box.info.replication[id]
@@ -484,8 +484,8 @@ end
 local function storage_wait_pairsync(s1, s2)
     s1:wait_vclock_of(s2)
     s2:wait_vclock_of(s1)
-    s1:exec(storage_wait_follow_f, {wait_timeout, s2:instance_id()})
-    s2:exec(storage_wait_follow_f, {wait_timeout, s1:instance_id()})
+    s1:exec(storage_wait_follow_f, {s2:instance_id()})
+    s2:exec(storage_wait_follow_f, {s1:instance_id()})
 end
 
 --
@@ -573,4 +573,5 @@ return {
     router_cfg = router_cfg,
     router_disconnect = router_disconnect,
     uuid_from_int = uuid_from_int,
+    wait_timeout = wait_timeout,
 }

--- a/test/rebalancer/bucket_ref.result
+++ b/test/rebalancer/bucket_ref.result
@@ -168,11 +168,11 @@ vshard.storage.bucket_unref(1, 'write') -- Error, no refs.
 ---
 - null
 - bucket_id: 1
-  reason: no refs
-  code: 1
+  reason: no rw refs on unref
+  code: 34
   type: ShardingError
-  message: 'Cannot perform action with bucket 1, reason: no refs'
-  name: WRONG_BUCKET
+  message: 'Bucket 1 is corrupted: no rw refs on unref'
+  name: BUCKET_IS_CORRUPTED
 ...
 vshard.storage.bucket_ref(1, 'read')
 ---

--- a/test/rebalancer/rebalancer2.result
+++ b/test/rebalancer/rebalancer2.result
@@ -116,7 +116,7 @@ test_run:switch('fullbox_2_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = true
  | ---
  | ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
  | ---
  | ...
 
@@ -127,7 +127,7 @@ test_run:switch('fullbox_3_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = true
  | ---
  | ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
  | ---
  | ...
 
@@ -160,7 +160,7 @@ test_run:switch('fullbox_2_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = false
  | ---
  | ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
  | ---
  | ...
 vshard.storage.recovery_wakeup()
@@ -174,7 +174,7 @@ test_run:switch('fullbox_3_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = false
  | ---
  | ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
  | ---
  | ...
 vshard.storage.recovery_wakeup()

--- a/test/rebalancer/rebalancer2.test.lua
+++ b/test/rebalancer/rebalancer2.test.lua
@@ -62,11 +62,11 @@ end
 -- wouldn't cover the issue.
 test_run:switch('fullbox_2_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = true
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 
 test_run:switch('fullbox_3_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = true
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 
 test_run:switch('default')
 command = "cfg.sharding[util.replicasets[1]].weight = 0 vshard.storage.cfg(cfg, util.name_to_uuid[NAME])"
@@ -79,12 +79,12 @@ end)
 
 test_run:switch('fullbox_2_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = false
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 vshard.storage.recovery_wakeup()
 
 test_run:switch('fullbox_3_a')
 vshard.storage.internal.errinj.ERRINJ_RECEIVE_PARTIALLY = false
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 vshard.storage.recovery_wakeup()
 
 test_run:switch('fullbox_1_a')

--- a/test/router/router.result
+++ b/test/router/router.result
@@ -312,7 +312,7 @@ _ = test_run:switch('storage_2_a')
 ...
 -- Pause recovery. It is too aggressive, and the test needs to see buckets in
 -- their intermediate states.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 box.space._bucket:replace({1, vshard.consts.BUCKET.SENDING, util.replicasets[1]})
@@ -322,7 +322,7 @@ box.space._bucket:replace({1, vshard.consts.BUCKET.SENDING, util.replicasets[1]}
 _ = test_run:switch('storage_1_a')
 ---
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 box.space._bucket:replace({1, vshard.consts.BUCKET.RECEIVING, util.replicasets[2]})
@@ -355,13 +355,13 @@ box.space._bucket:delete({1})
 ---
 - [1, 'receiving', '<replicaset_2>']
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 ---
 ...
 _ = test_run:switch('storage_2_a')
 ---
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 ---
 ...
 _ = test_run:switch('router_1')

--- a/test/router/router.test.lua
+++ b/test/router/router.test.lua
@@ -116,11 +116,11 @@ replicaset, err = vshard.router.bucket_discovery(2); return err == nil or err
 _ = test_run:switch('storage_2_a')
 -- Pause recovery. It is too aggressive, and the test needs to see buckets in
 -- their intermediate states.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 box.space._bucket:replace({1, vshard.consts.BUCKET.SENDING, util.replicasets[1]})
 
 _ = test_run:switch('storage_1_a')
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 box.space._bucket:replace({1, vshard.consts.BUCKET.RECEIVING, util.replicasets[2]})
 
 _ = test_run:switch('router_1')
@@ -131,10 +131,10 @@ util.check_error(vshard.router.call, 1, 'write', 'echo', {123})
 
 _ = test_run:switch('storage_1_a')
 box.space._bucket:delete({1})
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 
 _ = test_run:switch('storage_2_a')
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 
 _ = test_run:switch('router_1')
 

--- a/test/storage-luatest/garbage_collector_test.lua
+++ b/test/storage-luatest/garbage_collector_test.lua
@@ -110,7 +110,7 @@ test_group.test_basic = function(g)
             ivshard.storage.internal.collect_bucket_garbage_fiber, nil)
 
         -- Bucket GC deletes the buckets eventually.
-        _G.wait_bucket_gc(timeout)
+        _G.bucket_gc_wait(timeout)
 
         -- Ensure both the sent buckets and their data are gone.
         for _, bid in pairs(sent_bids) do
@@ -188,7 +188,7 @@ test_group.test_yield_before_send_commit = function(g)
 
         -- Bucket GC should react on commit. Not wakeup on replace, notice no
         -- changes, and go to sleep.
-        _G.wait_bucket_gc(timeout)
+        _G.bucket_gc_wait(timeout)
         ilt.assert_equals(s:count(), 0, 'no garbage data')
 
         -- Restore the bucket for next tests.

--- a/test/storage-luatest/storage_1_1_test.lua
+++ b/test/storage-luatest/storage_1_1_test.lua
@@ -142,7 +142,7 @@ test_group.test_bucket_send_field_types = function(g)
 
     -- Cleanup.
     g.replica_1_a:exec(function(timeout)
-        _G.wait_bucket_gc(timeout)
+        _G.bucket_gc_wait(timeout)
     end, {wait_timeout})
 
     g.replica_2_a:exec(function(bid, timeout, dst)
@@ -151,7 +151,7 @@ test_group.test_bucket_send_field_types = function(g)
                                                     {timeout = timeout})
         ilt.assert_equals(err, nil, 'bucket_send no error')
         ilt.assert(ok, 'bucket_send ok')
-        _G.wait_bucket_gc()
+        _G.bucket_gc_wait(timeout)
     end, {bid, wait_timeout, g.replica_1_a:replicaset_uuid()})
 
     vtest.storage_exec_each_master(g, function()

--- a/test/storage-luatest/storage_2_test.lua
+++ b/test/storage-luatest/storage_2_test.lua
@@ -1,0 +1,242 @@
+local t = require('luatest')
+local vtest = require('test.luatest_helpers.vtest')
+local vutil = require('vshard.util')
+local vconst = require('vshard.consts')
+local verror = require('vshard.error')
+
+local group_config = {{}}
+
+if vutil.feature.memtx_mvcc then
+    table.insert(group_config, {memtx_use_mvcc_engine = true})
+end
+
+local test_group = t.group('storage', group_config)
+
+local cfg_template = {
+    sharding = {
+        {
+            replicas = {
+                replica_1_a = {
+                    master = true,
+                },
+                replica_1_b = {},
+            },
+        },
+    },
+    bucket_count = 20
+}
+local cluster_cfg
+
+test_group.before_all(function(g)
+    cfg_template.memtx_use_mvcc_engine = g.params.memtx_use_mvcc_engine
+    cluster_cfg = vtest.config_new(cfg_template)
+
+    vtest.storage_new(g, cluster_cfg)
+    vtest.storage_bootstrap(g, cluster_cfg)
+    vtest.storage_wait_vclock_all(g)
+    vtest.storage_rebalancer_disable(g)
+    g.replica_1_a:exec(function()
+        _G.bucket_recovery_pause()
+    end)
+end)
+
+test_group.after_all(function(g)
+    g.cluster:drop()
+end)
+
+local function bucket_refro(bid)
+    local ok, err = ivshard.storage.bucket_refro(bid)
+    ilt.assert_equals(err, nil)
+    ilt.assert(ok)
+end
+
+local function bucket_refro_fail(bid, errcode)
+    local ok, err = ivshard.storage.bucket_refro(bid)
+    ilt.assert(not ok)
+    ilt.assert_equals(err.code, errcode)
+end
+
+local function bucket_unrefro(bid)
+    local ok, err = ivshard.storage.bucket_unrefro(bid)
+    ilt.assert_equals(err, nil)
+    ilt.assert(ok)
+end
+
+local function bucket_gc_wait()
+    _G.bucket_gc_wait()
+end
+
+local function bucket_update_status(bid, status)
+    box.space._bucket:update({bid}, {{'=', 2, status}})
+end
+
+local function bucket_force_create(bid)
+    ivshard.storage.bucket_force_create(bid)
+end
+
+local function bucket_force_drop(bid)
+    ivshard.storage.bucket_force_drop(bid)
+end
+
+local function bucket_check_no_ref(bid)
+    -- When called after GC polling, the bucket can be not visible in _bucket
+    -- already, but not committed yet, and its ref could still be there.
+    _G.wal_sync()
+    ilt.assert_equals(ivshard.storage.internal.bucket_refs[bid], nil)
+end
+
+local function bucket_check_has_ref(bid)
+    ilt.assert_not_equals(ivshard.storage.internal.bucket_refs[bid], nil)
+end
+
+local function bucket_check_ref_ro_lock(bid)
+    ilt.assert(ivshard.storage.internal.bucket_refs[bid].ro_lock)
+end
+
+local function bucket_check_ref_no_ro_lock(bid)
+    ilt.assert(not ivshard.storage.internal.bucket_refs[bid].ro_lock)
+end
+
+--
+-- Test what happens when a bucket is unable to get new reads nor writes.
+--
+local function test_bucket_space_trigger_garbage(g, status)
+    local rep_a = g.replica_1_a
+    local rep_b = g.replica_1_b
+
+    local bid = vtest.storage_first_bucket(rep_a)
+    -- Ref the bucket to make it create a cashed ref object with non-zero refs
+    -- in it. It should prevent its garbage collection until the refs are gone.
+    rep_b:exec(bucket_refro, {bid})
+    rep_a:exec(bucket_refro, {bid})
+
+    -- Turn the bucket into garbage.
+    t.assert_items_include({vconst.BUCKET.SENT, vconst.BUCKET.GARBAGE},
+                           {status})
+    rep_a:exec(bucket_update_status, {bid, status})
+    rep_a:exec(bucket_refro_fail, {bid, verror.code.BUCKET_IS_LOCKED})
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_refro_fail, {bid, verror.code.BUCKET_IS_LOCKED})
+
+    -- Collect the bucket.
+    rep_b:exec(bucket_unrefro, {bid})
+    rep_a:exec(bucket_unrefro, {bid})
+    rep_a:exec(bucket_gc_wait)
+
+    -- Ensure its ref is gone on all nodes.
+    rep_a:exec(bucket_check_no_ref, {bid})
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    -- Ensure it works when a bucket has no refs too.
+    rep_a:exec(bucket_force_create, {bid})
+    rep_a:exec(bucket_update_status, {bid, status})
+    rep_a:exec(bucket_gc_wait)
+
+    rep_a:exec(bucket_check_no_ref, {bid})
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    -- Cleanup.
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+end
+
+local function test_bucket_space_trigger_active(g, status)
+    local rep_a = g.replica_1_a
+    local rep_b = g.replica_1_b
+
+    -- Make a non-active bucket.
+    local bid = vtest.storage_first_bucket(rep_a)
+    rep_a:exec(bucket_update_status, {bid, vconst.BUCKET.SENDING})
+    rep_a:exec(bucket_check_no_ref)
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref)
+
+    -- Bucket turn into an active one works fine when it had no refs.
+    t.assert_items_include({vconst.BUCKET.ACTIVE, vconst.BUCKET.PINNED},
+                           {status})
+    rep_a:exec(bucket_update_status, {bid, status})
+    rep_a:exec(bucket_check_no_ref)
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref)
+
+    -- Turn from a non-active ro-locked bucket back into active is an abnormal
+    -- situation. Nonetheless, should drop the lock then.
+    rep_a:exec(bucket_refro, {bid})
+    rep_b:exec(bucket_refro, {bid})
+
+    rep_a:exec(bucket_update_status, {bid, vconst.BUCKET.SENT})
+    rep_a:exec(bucket_check_ref_ro_lock, {bid})
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_ref_ro_lock, {bid})
+
+    rep_a:exec(bucket_update_status, {bid, status})
+    rep_a:exec(bucket_check_ref_no_ro_lock, {bid})
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_ref_no_ro_lock, {bid})
+
+    -- Restore.
+    rep_a:exec(bucket_unrefro, {bid})
+    rep_b:exec(bucket_unrefro, {bid})
+    rep_a:exec(bucket_force_drop, {bid})
+    rep_a:exec(bucket_check_no_ref)
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+end
+
+test_group.test_bucket_space_trigger_sent = function(g)
+    test_bucket_space_trigger_garbage(g, vconst.BUCKET.SENT)
+end
+
+test_group.test_bucket_space_trigger_garbage = function(g)
+    test_bucket_space_trigger_garbage(g, vconst.BUCKET.GARBAGE)
+end
+
+test_group.test_bucket_space_trigger_active = function(g)
+    test_bucket_space_trigger_active(g, vconst.BUCKET.ACTIVE)
+end
+
+test_group.test_bucket_space_trigger_pinned = function(g)
+    test_bucket_space_trigger_active(g, vconst.BUCKET.PINNED)
+end
+
+test_group.test_bucket_space_triggers_receiving = function(g)
+    local rep_a = g.replica_1_a
+    local rep_b = g.replica_1_b
+
+    -- Commit of RECEIVING bucket works fine when no refs. That is a part of the
+    -- normal process of bucket receipt.
+    local bid = vtest.storage_first_bucket(rep_a)
+    rep_a:exec(bucket_force_drop, {bid})
+    rep_a:exec(bucket_update_status, {bid, vconst.BUCKET.RECEIVING})
+    rep_a:exec(bucket_check_no_ref, {bid})
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    rep_a:exec(bucket_force_drop, {bid})
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+
+    -- Commit of RECEIVING bucket works fine when has refs. Abnormal situation.
+    -- Nonetheless, should drop the refs then.
+    rep_a:exec(bucket_refro, {bid})
+    rep_b:exec(bucket_refro, {bid})
+    rep_a:exec(bucket_check_has_ref, {bid})
+    rep_a:exec(bucket_update_status, {bid, vconst.BUCKET.RECEIVING})
+    rep_a:exec(bucket_check_no_ref, {bid})
+
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    -- Restore.
+    rep_a:exec(bucket_force_drop, {bid})
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+end

--- a/test/storage-luatest/storage_2_test.lua
+++ b/test/storage-luatest/storage_2_test.lua
@@ -1,4 +1,5 @@
 local t = require('luatest')
+local fiber = require('fiber')
 local vtest = require('test.luatest_helpers.vtest')
 local vutil = require('vshard.util')
 local vconst = require('vshard.consts')
@@ -95,6 +96,38 @@ end
 
 local function bucket_check_ref_no_ro_lock(bid)
     ilt.assert(not ivshard.storage.internal.bucket_refs[bid].ro_lock)
+end
+
+local function call_long_start(storage, bid, mode, err)
+     local f = fiber.new(storage.exec, storage, function(bid, mode, err)
+        rawset(_G, 'do_wait', true)
+        rawset(_G, 'wait_f', function()
+            rawset(_G, 'is_waiting', true)
+            while _G.do_wait do
+                ifiber.sleep(0.01)
+            end
+            -- Restore.
+            _G.is_waiting = false
+            _G.do_wait = true
+            if err ~= nil then
+                box.error(box.error.PROC_LUA, err)
+            end
+            return true
+        end)
+        return ivshard.storage.call(bid, mode, 'wait_f')
+    end, {bid, mode, err})
+    f:set_joinable(true)
+    t.helpers.retrying({timeout = vtest.wait_timeout}, storage.exec, storage,
+        function()
+            if not _G.is_waiting then
+                error('No request')
+            end
+        end)
+    return f
+end
+
+local function call_long_stop()
+    _G.do_wait = false
 end
 
 --
@@ -239,4 +272,99 @@ test_group.test_bucket_space_triggers_receiving = function(g)
     rep_a:exec(bucket_force_drop, {bid})
     rep_a:exec(bucket_force_create, {bid})
     rep_b:wait_vclock_of(rep_a)
+end
+
+--
+-- Callro in the end can notice that the bucket is gone. Can't treat the request
+-- as successful then - it could read a partially deleted bucket.
+--
+local function test_storage_callro_refro_loss(g, user_err)
+    local rep_a = g.replica_1_a
+    local rep_b = g.replica_1_b
+
+    local bid = vtest.storage_first_bucket(rep_a)
+    -- Start an RO request on the replica.
+    local f = call_long_start(rep_b, bid, 'read', user_err)
+
+    -- The bucket becomes deleted on the master due to any reason.
+    rep_a:exec(bucket_force_drop, {bid})
+    rep_b:wait_vclock_of(rep_a)
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    -- The replica should fail to complete the RO request.
+    rep_b:exec(call_long_stop)
+    local ok_fiber, ok_storage, err = f:join()
+    t.assert(ok_fiber)
+    t.assert_equals(ok_storage, nil)
+    -- The error is critical. Bucket refs are messed up.
+    t.assert(err.code, verror.code.BUCKET_IS_CORRUPTED)
+    -- The user's exception is also preserved.
+    if user_err ~= nil then
+        t.assert_equals(err.prev.message, user_err)
+    else
+        t.assert_equals(err.prev, nil)
+    end
+    rep_b:exec(bucket_check_no_ref, {bid})
+
+    -- Restore.
+    rep_a:exec(bucket_gc_wait)
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+end
+
+test_group.test_storage_callro_refro_loss = function(g)
+    test_storage_callro_refro_loss(g)
+    test_storage_callro_refro_loss(g, 'test_error')
+end
+
+--
+-- Callrw in the end can notice that the bucket is gone. Can't treat the request
+-- as successful then - it could write into a partially deleted bucket.
+--
+local function test_storage_callro_refrw_loss(g, user_err)
+    local rep_a = g.replica_1_a
+    local rep_b = g.replica_1_b
+
+    local bid = vtest.storage_first_bucket(rep_a)
+    -- Start an RW request on the master.
+    local f = call_long_start(rep_a, bid, 'write', user_err)
+
+    -- Change the master role during the RW request execution.
+    local new_cfg_template = table.deepcopy(cfg_template)
+    local rs1_replicas = new_cfg_template.sharding[1].replicas
+    rs1_replicas.replica_1_a.master = false
+    rs1_replicas.replica_1_b.master = true
+    local new_cluster_cfg = vtest.config_new(new_cfg_template)
+    vtest.storage_cfg(g, new_cluster_cfg)
+
+    -- The bucket becomes deleted on the new master due to any reason.
+    rep_b:exec(bucket_force_drop, {bid})
+    rep_a:wait_vclock_of(rep_a)
+    rep_a:exec(bucket_check_no_ref, {bid})
+
+    -- The old master should fail to complete the RW request.
+    rep_a:exec(call_long_stop)
+    local ok_fiber, ok_storage, err = f:join()
+    t.assert(ok_fiber)
+    t.assert_equals(ok_storage, nil)
+    -- The error is critical. Bucket refs are messed up.
+    t.assert(err.code, verror.code.BUCKET_IS_CORRUPTED)
+    -- The user's exception is also preserved.
+    if user_err ~= nil then
+        t.assert_equals(err.prev.message, user_err)
+    else
+        t.assert_equals(err.prev, nil)
+    end
+    rep_a:exec(bucket_check_no_ref, {bid})
+
+    -- Restore.
+    vtest.storage_cfg(g, cluster_cfg)
+    rep_a:exec(bucket_gc_wait)
+    rep_a:exec(bucket_force_create, {bid})
+    rep_b:wait_vclock_of(rep_a)
+end
+
+test_group.test_storage_callro_refrw_loss = function(g)
+    test_storage_callro_refrw_loss(g)
+    test_storage_callro_refrw_loss(g, 'test_error')
 end

--- a/test/storage/recovery.result
+++ b/test/storage/recovery.result
@@ -30,7 +30,7 @@ _ = test_run:switch("storage_2_a")
 ...
 -- Pause until restart. Otherwise recovery does its job too fast and does not
 -- allow to simulate the intermediate state.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 vshard.storage.rebalancer_disable()
@@ -39,7 +39,7 @@ vshard.storage.rebalancer_disable()
 _ = test_run:switch("storage_1_a")
 ---
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 -- Create buckets sending to rs2 and restart - recovery must

--- a/test/storage/recovery.test.lua
+++ b/test/storage/recovery.test.lua
@@ -12,11 +12,11 @@ util.push_rs_filters(test_run)
 _ = test_run:switch("storage_2_a")
 -- Pause until restart. Otherwise recovery does its job too fast and does not
 -- allow to simulate the intermediate state.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 vshard.storage.rebalancer_disable()
 
 _ = test_run:switch("storage_1_a")
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 
 -- Create buckets sending to rs2 and restart - recovery must
 -- garbage some of them and activate others. Receiving buckets

--- a/test/storage/recovery_errinj.result
+++ b/test/storage/recovery_errinj.result
@@ -37,13 +37,13 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 ...
 -- Pause recovery. Otherwise it does its job too fast and does not allow to
 -- simulate the intermediate state.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 _ = test_run:switch('storage_1_a')
 ---
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 _bucket = box.space._bucket
@@ -84,13 +84,13 @@ _bucket:get{1}
 ---
 - [1, 'active']
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 ---
 ...
 _ = test_run:switch('storage_1_a')
 ---
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 ---
 ...
 wait_bucket_is_collected(1)

--- a/test/storage/recovery_errinj.test.lua
+++ b/test/storage/recovery_errinj.test.lua
@@ -16,10 +16,10 @@ _ = test_run:switch('storage_2_a')
 vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 -- Pause recovery. Otherwise it does its job too fast and does not allow to
 -- simulate the intermediate state.
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 
 _ = test_run:switch('storage_1_a')
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 _bucket = box.space._bucket
 _bucket:replace{1, vshard.consts.BUCKET.ACTIVE, util.replicasets[2]}
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
@@ -32,10 +32,10 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
 _bucket = box.space._bucket
 while _bucket:get{1}.status ~= vshard.consts.BUCKET.ACTIVE do fiber.sleep(0.01) end
 _bucket:get{1}
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 
 _ = test_run:switch('storage_1_a')
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 wait_bucket_is_collected(1)
 
 _ = test_run:switch("default")

--- a/test/storage/storage.result
+++ b/test/storage/storage.result
@@ -905,7 +905,7 @@ assert(lstorage.bucket_are_all_rw())
 ---
 - true
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
 -- Let it stuck in the errinj.
@@ -932,7 +932,7 @@ assert(lstorage.bucket_are_all_rw())
 ---
 - true
 ...
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 ---
 ...
 --

--- a/test/storage/storage.test.lua
+++ b/test/storage/storage.test.lua
@@ -282,7 +282,7 @@ assert(not ok and err.message)
 -- Bucket_are_all_rw() registry function.
 --
 assert(lstorage.bucket_are_all_rw())
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = true
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 -- Let it stuck in the errinj.
 vshard.storage.recovery_wakeup()
 vshard.storage.bucket_force_create(10)
@@ -290,7 +290,7 @@ box.space._bucket:update(10, {{'=', 2, vshard.consts.BUCKET.SENDING}})
 assert(not lstorage.bucket_are_all_rw())
 box.space._bucket:update(10, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 assert(lstorage.bucket_are_all_rw())
-vshard.storage.internal.errinj.ERRINJ_NO_RECOVERY = false
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
 
 --
 -- Internal info function.

--- a/test/unit-luatest/error_test.lua
+++ b/test/unit-luatest/error_test.lua
@@ -1,0 +1,35 @@
+local t = require('luatest')
+local vutil = require('vshard.util')
+local verror = require('vshard.error')
+
+local g = t.group('error')
+
+g.test_box_error_prev = function()
+    t.run_only_if(vutil.feature.error_stack)
+
+    local code = box.error.PROC_LUA
+    local e1 = box.error.new(code, 'err1')
+    local e2 = box.error.new(code, 'err2')
+    local e3 = box.error.new(code, 'err3')
+    e1:set_prev(e2)
+    e2:set_prev(e3)
+
+    local ve1 = verror.box(e1)
+    local ve2 = ve1.prev
+    ve1.prev = nil
+    local ve3 = ve2.prev
+    ve2.prev = nil
+    t.assert_type(ve1, 'table')
+    t.assert_type(ve2, 'table')
+    t.assert_type(ve3, 'table')
+
+    e1 = e1:unpack()
+    e1.prev = nil
+    e2 = e2:unpack()
+    e2.prev = nil
+    e3 = e3:unpack()
+
+    t.assert_equals(e1, ve1)
+    t.assert_equals(e2, ve2)
+    t.assert_equals(e3, ve3)
+end

--- a/vshard/error.lua
+++ b/vshard/error.lua
@@ -201,9 +201,18 @@ end
 --   'ShardingError', one of codes below and optional
 --   message.
 --
-
+local box_error_mt = {__tostring = json.encode}
 local function box_error(original_error)
-    return setmetatable(original_error:unpack(), {__tostring = json.encode})
+    local res = setmetatable(original_error:unpack(), box_error_mt)
+    local pos = res
+    local prev = pos.prev
+    while prev ~= nil do
+        prev = setmetatable(prev:unpack(), box_error_mt)
+        pos.prev = prev
+        pos = prev
+        prev = pos.prev
+    end
+    return res
 end
 
 --

--- a/vshard/error.lua
+++ b/vshard/error.lua
@@ -170,6 +170,14 @@ local error_message_template = {
         msg = 'Storage is disabled: %s',
         args = {'reason'}
     },
+    [34] = {
+        -- That is similar to WRONG_BUCKET, but the latter is not critical. It
+        -- usually can be retried. Corruption is a critical error, it requires
+        -- more attention.
+        name = 'BUCKET_IS_CORRUPTED',
+        msg = 'Bucket %d is corrupted: %s',
+        args = {'bucket_id', 'reason'}
+    },
 }
 
 --

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -1189,8 +1189,8 @@ local function bucket_unrefro(bucket_id)
     local ref = M.bucket_refs[bucket_id]
     local count = ref and ref.ro or 0
     if count == 0 then
-        return nil, lerror.vshard(lerror.code.WRONG_BUCKET, bucket_id,
-                                  "no refs", nil)
+        return nil, lerror.vshard(lerror.code.BUCKET_IS_CORRUPTED, bucket_id,
+                                  "no ro refs on unref")
     end
     if count == 1 then
         ref.ro = 0
@@ -1244,8 +1244,8 @@ end
 local function bucket_unrefrw(bucket_id)
     local ref = M.bucket_refs[bucket_id]
     if not ref or ref.rw == 0 then
-        return nil, lerror.vshard(lerror.code.WRONG_BUCKET, bucket_id,
-                                  "no refs", nil)
+        return nil, lerror.vshard(lerror.code.BUCKET_IS_CORRUPTED, bucket_id,
+                                  "no rw refs on unref")
     end
     if ref.rw == 1 and ref.rw_lock then
         ref.rw = 0

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -80,7 +80,7 @@ if not M then
             ERRINJ_LONG_RECEIVE = false,
             ERRINJ_LAST_RECEIVE_DELAY = false,
             ERRINJ_RECEIVE_PARTIALLY = false,
-            ERRINJ_NO_RECOVERY = false,
+            ERRINJ_RECOVERY_PAUSE = false,
             ERRINJ_UPGRADE = false,
             ERRINJ_DISCOVERY = false,
         },
@@ -928,8 +928,9 @@ local function recovery_f()
     -- Interrupt recovery if a module has been reloaded. Perhaps,
     -- there was found a bug, and reload fixes it.
     while module_version == M.module_version do
-        if M.errinj.ERRINJ_NO_RECOVERY then
-            lfiber.yield()
+        if M.errinj.ERRINJ_RECOVERY_PAUSE then
+            M.errinj.ERRINJ_RECOVERY_PAUSE = 1
+            lfiber.sleep(0.01)
             goto continue
         end
         is_all_recovered = true

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -310,6 +310,7 @@ local feature = {
         -- Backported into 2.10 since EE 2.10.0-2-g6b29095.
         return version_is_at_least(2, 10, 0, nil, 0, 2)
     end)(),
+    error_stack = version_is_at_least(2, 4, 0, nil, 0, 0),
 }
 
 return {


### PR DESCRIPTION
The patchset starts work on the big issue of bucket refs being not protected from incorrect changes of _bucket. Mostly that is about the main bug which allows to garbage collect a bucket on a master instance even if it has some read-requests in progress on replicas. That makes the requests potentially access inconsistent partially deleted data.

The fix consists of multiple steps which are being sent as separate patchsets. Otherwise there would be no progress for too long while I am busy with non-vshard activities in the meantime.

#173