### PR TITLE
router: auto and manual enable/disable

### DIFF
--- a/test/instances/router.lua
+++ b/test/instances/router.lua
@@ -6,6 +6,7 @@ local helpers = require('test.luatest_helpers')
 -- able to use the libs in server:exec() calls and not get upvalue errors if the
 -- same lib is declared in the _test.lua file.
 --
+_G.ifiber = require('fiber')
 _G.imsgpack = require('msgpack')
 _G.ivtest = require('test.luatest_helpers.vtest')
 _G.iwait_timeout = _G.ivtest.wait_timeout

--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -524,6 +524,7 @@ end
 
 --
 -- Create a new router in the cluster.
+-- If no cfg was passed configuration should be done manually with server:exec
 --
 local function router_new(g, name, cfg)
     if not g.cluster then
@@ -535,7 +536,9 @@ local function router_new(g, name, cfg)
     g[name] = server
     g.cluster:add_server(server)
     server:start()
-    router_cfg(server, cfg)
+    if cfg then
+        router_cfg(server, cfg)
+    end
     return server
 end
 

--- a/vshard/error.lua
+++ b/vshard/error.lua
@@ -178,6 +178,11 @@ local error_message_template = {
         msg = 'Bucket %d is corrupted: %s',
         args = {'bucket_id', 'reason'}
     },
+    [35] = {
+        name = 'ROUTER_IS_DISABLED',
+        msg = 'Router is disabled: %s',
+        args = {'reason'}
+    },
 }
 
 --


### PR DESCRIPTION
This patch introduces protecting router's API while its configuration
is not done as accessing these functions at that time is not safe and
can cause low level errors like 'bad arguments' or 'no such function'.

Now all non-trivial vshard.router functions are disabled until
vshard.router.cfg (or vshard.router.new) is finished and error is
raised in case of an attempt to access them.

Manual API's enabling/disabling is also introduced in this patch.
The behavior of router's protection is similar to the storage's one.

Closes #291