### PR TITLE
test: fix flaky rebalancer/stress_add_remove_rs.test.lua

### DIFF
--- a/test/lua_libs/storage_template.lua
+++ b/test/lua_libs/storage_template.lua
@@ -91,6 +91,8 @@ function bootstrap_storage(engine)
         box.schema.role.grant('public', 'execute', 'function', 'space_get')
         box.schema.func.create('space_insert')
         box.schema.role.grant('public', 'execute', 'function', 'space_insert')
+        box.schema.func.create('space_truncate', {setuid = true})
+        box.schema.role.grant('public', 'execute', 'function', 'space_truncate')
         box.schema.func.create('do_replace')
         box.schema.role.grant('public', 'execute', 'function', 'do_replace')
         box.schema.func.create('do_select')
@@ -118,6 +120,10 @@ end
 
 function space_insert(space_name, tuple)
     return box.space[space_name]:insert(tuple)
+end
+
+function space_truncate(space_name)
+    return box.space[space_name]:truncate()
 end
 
 function do_replace(...)

--- a/test/rebalancer/rebalancer_utils.lua
+++ b/test/rebalancer/rebalancer_utils.lua
@@ -70,8 +70,18 @@ local function check_loading_result()
 	return true
 end
 
+local function truncate_everywhere_space(space_name)
+	for _, replicaset in pairs(vshard.router.static.replicasets) do
+		local replica = replicaset.replica
+		if replica ~= nil and replica:is_connected() then
+			replica.conn:call('space_truncate', {space_name}, {timeout = 100})
+		end
+	end
+end
+
 return {
 	stop_loading = stop_loading,
 	start_loading = start_loading,
 	check_loading_result = check_loading_result,
+	truncate_everywhere_space = truncate_everywhere_space,
 }

--- a/test/rebalancer/stress_add_remove_rs.result
+++ b/test/rebalancer/stress_add_remove_rs.result
@@ -239,6 +239,9 @@ test_run:switch('router_1')
 ---
 - true
 ...
+util.truncate_everywhere_space('test')
+---
+...
 util.start_loading()
 ---
 ...
@@ -392,6 +395,9 @@ check_consistency()
 test_run:switch('router_1')
 ---
 - true
+...
+util.truncate_everywhere_space('test')
+---
 ...
 util.start_loading()
 ---

--- a/test/rebalancer/stress_add_remove_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_rs.test.lua
@@ -94,6 +94,7 @@ check_consistency()
 -- out.
 --
 test_run:switch('router_1')
+util.truncate_everywhere_space('test')
 util.start_loading()
 test_run:switch('box_3_a')
 remove_replicaset_first_stage()
@@ -152,6 +153,7 @@ check_consistency()
 -- When buckets are moved out from third replicaset, remove it
 -- from config.
 test_run:switch('router_1')
+util.truncate_everywhere_space('test')
 util.start_loading()
 test_run:switch('box_2_a')
 remove_replicaset_second_stage()


### PR DESCRIPTION
Sometimes `rebalancer/stress_add_remove_rs.test.lua` hangs. This happens on both storage engines. We need to fix that.