### PR TITLE
replicaset: reconnect after fiber kill

### DIFF
--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -7,7 +7,7 @@ local uuid = require('uuid')
 local yaml = require('yaml')
 local vrepset = require('vshard.replicaset')
 
-local wait_timeout = 120
+local wait_timeout = 50
 -- Use it in busy-loops like `while !cond do fiber.sleep(busy_step) end`.
 local busy_step = 0.005
 local uuid_idx = 1

--- a/test/storage/recovery.result
+++ b/test/storage/recovery.result
@@ -122,6 +122,9 @@ while _bucket:count() ~= 2 do vshard.storage.recovery_wakeup() fiber.sleep(0.1) 
 _ = test_run:switch('storage_1_a')
 ---
 ...
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
+---
+...
 _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 ---
 - [1, 'sending', '<replicaset_2>']

--- a/test/storage/recovery.test.lua
+++ b/test/storage/recovery.test.lua
@@ -58,6 +58,7 @@ while _bucket:count() ~= 2 do vshard.storage.recovery_wakeup() fiber.sleep(0.1) 
 -- must restore buckets, when the destination is up.
 --
 _ = test_run:switch('storage_1_a')
+vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 _ = test_run:switch('storage_2_a')
 _bucket:replace{1, vshard.consts.BUCKET.ACTIVE}


### PR DESCRIPTION
Currently if we kill net.box's fibers the connection goes into
`error_reconnect` state. However, it's not reconnecting anymore.

This patch introduces reconnecting in that case. It should be used
wisely, though. Fiber's killing doesn't happen instantly and if the
user doesn't wait util fiber's status is `dead` and makes the request
immediately, exception will be probably thrown as the fiber can die
in the middle of request.

So, after fiber kill wait until it's really dead and make a request
only after that.

Closes #341