### PR TITLE
ci: disable router/router.test.lua

### DIFF
--- a/test/router/suite.ini
+++ b/test/router/suite.ini
@@ -3,6 +3,7 @@ core = tarantool
 description = Router tests
 script = test.lua
 is_parallel = False
+disabled = router.test.lua
 lua_libs = ../lua_libs/util.lua ../lua_libs/git_util.lua
            ../lua_libs/storage_template.lua
            ../../example/localcfg.lua


### PR DESCRIPTION
Tarantool's CI fails constantly on router/router.test.lua.
Let's disable this test before the fix is commited.