### PR TITLE
Fixed rewrited error arguments

### DIFF
--- a/test/multiple_routers/multiple_routers.result
+++ b/test/multiple_routers/multiple_routers.result
@@ -176,10 +176,11 @@ util = require('util')
 util.check_error(vshard.router.new, 'router_2', configs.cfg_2)
 ---
 - null
-- type: ShardingError
-  code: 21
+- code: 21
+  type: ShardingError
   name: ROUTER_ALREADY_EXISTS
   message: Router with name router_2 already exists
+  router_name: router_2
 ...
 -- Reload router module.
 _, old_rs_1 = next(vshard.router.static.replicasets)

--- a/vshard/error.lua
+++ b/vshard/error.lua
@@ -109,7 +109,7 @@ local error_message_template = {
     [21] = {
         name = 'ROUTER_ALREADY_EXISTS',
         msg = 'Router with name %s already exists',
-        args = {'name'},
+        args = {'router_name'},
     },
     [22] = {
         name = 'BUCKET_IS_LOCKED',
@@ -195,7 +195,7 @@ local error_message_template = {
     [38] = {
         name = 'ROUTER_CFG_IS_IN_PROGRESS',
         msg = 'Configuration of the router with name %s is in progress',
-        args = {'name'}
+        args = {'router_name'}
     },
 }
 


### PR DESCRIPTION
This patch solves the problem when the error argument and the error name variable match, the variable is overwritten.

https://github.com/tarantool/vshard/blob/c508c8228ec81872cd246d3e062294a12d2d3e5d/vshard/error.lua#L109-L113

On line 256 we add the `name` key to ret, and on line 261 we overwrite it
https://github.com/tarantool/vshard/blob/c508c8228ec81872cd246d3e062294a12d2d3e5d/vshard/error.lua#L255-L261