### PR TITLE
storage: do bucket transitions checks on replace

### DIFF
--- a/test/failover/failover.result
+++ b/test/failover/failover.result
@@ -55,22 +55,25 @@ test_run:cmd('switch box_1_a')
 ---
 - true
 ...
-for i = 1, 30 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 30)
 ---
+- true
 ...
 test_run:cmd('switch box_2_a')
 ---
 - true
 ...
-for i = 31, 60 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(31, 30)
 ---
+- true
 ...
 test_run:cmd('switch box_3_b')
 ---
 - true
 ...
-for i = 61, 90 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(61, 30)
 ---
+- true
 ...
 test_run:cmd('switch default')
 ---

--- a/test/failover/failover.test.lua
+++ b/test/failover/failover.test.lua
@@ -24,13 +24,13 @@ end;
 test_run:cmd("setopt delimiter ''");
 
 test_run:cmd('switch box_1_a')
-for i = 1, 30 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 30)
 
 test_run:cmd('switch box_2_a')
-for i = 31, 60 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(31, 30)
 
 test_run:cmd('switch box_3_b')
-for i = 61, 90 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(61, 30)
 
 test_run:cmd('switch default')
 

--- a/test/lua_libs/util.lua
+++ b/test/lua_libs/util.lua
@@ -207,6 +207,14 @@ function is_timeout_error(err)
     return 'Timeout exceeded' == err.message or 'timed out' == err.message
 end
 
+-- Turn the bucket protection off on all instances, mentioned in the
+-- `cluster` table. Allows/prohibits to do whatever you want with
+-- `_bucket` space, according to the boolean `value`.
+local function map_bucket_protection(test_run, cluster, value)
+    return map_evals(test_run, cluster,
+        [[vshard.storage.internal.is_bucket_protected = ...]], value)
+end
+
 return {
     check_error = check_error,
     shuffle_masters = shuffle_masters,
@@ -214,6 +222,7 @@ return {
     wait_master = wait_master,
     has_same_fields = has_same_fields,
     map_evals = map_evals,
+    map_bucket_protection = map_bucket_protection,
     push_rs_filters = push_rs_filters,
     name_to_uuid = name_to_uuid,
     replicasets = replicasets,

--- a/test/misc/master_switch.result
+++ b/test/misc/master_switch.result
@@ -31,9 +31,9 @@ _ = test_run:cmd('stop server storage_1_b')
 _ = test_run:switch('storage_1_a')
 ---
 ...
-box.space._bucket:replace({1, vshard.consts.BUCKET.ACTIVE})
+vshard.storage.bucket_force_create(1)
 ---
-- [1, 'active']
+- true
 ...
 box.space.test:insert{1, 1, 1}
 ---
@@ -63,9 +63,9 @@ cfg.replication_connect_quorum = 1
 vshard.storage.cfg(cfg, util.name_to_uuid.storage_1_b)
 ---
 ...
-box.space._bucket:replace({1, vshard.consts.BUCKET.ACTIVE})
+vshard.storage.bucket_force_create(1)
 ---
-- [1, 'active']
+- true
 ...
 box.space.test:insert{1, 1, 2}
 ---

--- a/test/misc/master_switch.test.lua
+++ b/test/misc/master_switch.test.lua
@@ -10,7 +10,7 @@ util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, 'bootstrap_storage(\'memt
 
 _ = test_run:cmd('stop server storage_1_b')
 _ = test_run:switch('storage_1_a')
-box.space._bucket:replace({1, vshard.consts.BUCKET.ACTIVE})
+vshard.storage.bucket_force_create(1)
 box.space.test:insert{1, 1, 1}
 
 _ = test_run:switch('default')
@@ -21,7 +21,7 @@ cfg.sharding[util.replicasets[1]].replicas[util.name_to_uuid.storage_1_b].master
 cfg.sharding[util.replicasets[1]].replicas[util.name_to_uuid.storage_1_a].master = false
 cfg.replication_connect_quorum = 1
 vshard.storage.cfg(cfg, util.name_to_uuid.storage_1_b)
-box.space._bucket:replace({1, vshard.consts.BUCKET.ACTIVE})
+vshard.storage.bucket_force_create(1)
 box.space.test:insert{1, 1, 2}
 
 --

--- a/test/rebalancer/bucket_ref.result
+++ b/test/rebalancer/bucket_ref.result
@@ -49,10 +49,6 @@ vshard.storage.bucket_force_create(101, 100)
 _ = test_run:switch('box_1_a')
 ---
 ...
-box.space._bucket:replace{1, vshard.consts.BUCKET.ACTIVE}
----
-- [1, 'active']
-...
 vshard.storage.bucket_refro(1)
 ---
 - true

--- a/test/rebalancer/bucket_ref.test.lua
+++ b/test/rebalancer/bucket_ref.test.lua
@@ -20,8 +20,6 @@ _ = test_run:switch('box_2_a')
 vshard.storage.bucket_force_create(101, 100)
 _ = test_run:switch('box_1_a')
 
-box.space._bucket:replace{1, vshard.consts.BUCKET.ACTIVE}
-
 vshard.storage.bucket_refro(1)
 vshard.storage.buckets_info(1)
 

--- a/test/rebalancer/errinj.result
+++ b/test/rebalancer/errinj.result
@@ -59,8 +59,9 @@ wait_rebalancer_state('Total active bucket count is not equal to total', test_ru
 vshard.storage.rebalancer_disable()
 ---
 ...
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 ---
+- true
 ...
 test_run:switch('box_2_a')
 ---
@@ -69,8 +70,9 @@ test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 ---
+- true
 ...
 vshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = true
 ---

--- a/test/rebalancer/errinj.test.lua
+++ b/test/rebalancer/errinj.test.lua
@@ -32,11 +32,11 @@ _bucket = box.space._bucket
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 wait_rebalancer_state('Total active bucket count is not equal to total', test_run)
 vshard.storage.rebalancer_disable()
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('box_2_a')
 _bucket = box.space._bucket
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 vshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = true
 
 test_run:switch('box_1_a')

--- a/test/rebalancer/rebalancer.result
+++ b/test/rebalancer/rebalancer.result
@@ -77,8 +77,9 @@ cfg.rebalancer_max_receiving = 10
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 ---
 ...
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 ---
+- true
 ...
 test_run:switch('box_2_a')
 ---
@@ -87,8 +88,9 @@ test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 ---
+- true
 ...
 test_run:switch('box_1_a')
 ---
@@ -111,8 +113,9 @@ test_run:switch('box_2_a')
 ---
 - true
 ...
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 ---
+- true
 ...
 test_run:switch('default')
 ---
@@ -188,8 +191,9 @@ vshard.storage.rebalancer_disable()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 ---
 ...
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 ---
+- true
 ...
 test_run:switch('default')
 ---
@@ -322,8 +326,12 @@ _bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 vshard.storage.rebalancer_disable()
 ---
 ...
-for i = 91, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+wait_bucket_is_collected(100)
 ---
+...
+vshard.storage.bucket_force_create(91, 10)
+---
+- true
 ...
 space = box.space.test
 ---

--- a/test/rebalancer/rebalancer.result
+++ b/test/rebalancer/rebalancer.result
@@ -121,8 +121,7 @@ test_run:switch('default')
 ---
 - true
 ...
-util.map_evals(test_run, {REPLICASET_1},                                        \
-               [[vshard.storage.internal.is_bucket_protected = false]])
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
 ---
 ...
 test_run:switch('box_1_a')
@@ -132,15 +131,15 @@ test_run:switch('box_1_a')
 _bucket:truncate()
 ---
 ...
+vshard.storage.sync()
+---
+- true
+...
 test_run:switch('default')
 ---
 - true
 ...
-test_run:wait_lsn('box_1_b', 'box_1_a')
----
-...
-util.map_evals(test_run, {REPLICASET_1},                                        \
-               [[vshard.storage.internal.is_bucket_protected = true]])
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 ---
 ...
 test_run:switch('box_1_a')
@@ -199,8 +198,7 @@ test_run:switch('default')
 ---
 - true
 ...
-util.map_evals(test_run, {REPLICASET_2},                                        \
-               [[vshard.storage.internal.is_bucket_protected = false]])
+util.map_bucket_protection(test_run, {REPLICASET_2}, false)
 ---
 ...
 test_run:switch('box_2_a')
@@ -210,15 +208,15 @@ test_run:switch('box_2_a')
 _bucket:truncate()
 ---
 ...
+vshard.storage.sync()
+---
+- true
+...
 test_run:switch('default')
 ---
 - true
 ...
-test_run:wait_lsn('box_2_b', 'box_2_a')
----
-...
-util.map_evals(test_run, {REPLICASET_2},                                        \
-               [[vshard.storage.internal.is_bucket_protected = true]])
+util.map_bucket_protection(test_run, {REPLICASET_2}, true)
 ---
 ...
 test_run:switch('box_1_a')
@@ -305,6 +303,17 @@ wait_rebalancer_state("Rebalancer is disabled", test_run)
 -- sent.
 -- (See point (6) in the test plan)
 --
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
+test_run:switch('box_1_a')
+---
+- true
+...
 vshard.storage.rebalancer_enable()
 ---
 ...
@@ -319,10 +328,25 @@ _bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 ---
 - [150, 'active']
 ...
+vshard.storage.sync()
+---
+- true
+...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
 --
 -- Test garbage collector deletes sent buckets and their data.
 -- (See point (7) in the test plan)
 --
+test_run:switch('box_1_a')
+---
+- true
+...
 vshard.storage.rebalancer_disable()
 ---
 ...
@@ -356,6 +380,13 @@ space:replace{5, 151}
 ---
 - [5, 151]
 ...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_2}, false)
+---
+...
 test_run:switch('box_2_a')
 ---
 - true
@@ -364,6 +395,17 @@ space = box.space.test
 ---
 ...
 for i = 91, 100 do _bucket:delete{i} end
+---
+...
+vshard.storage.sync()
+---
+- true
+...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_2}, true)
 ---
 ...
 test_run:switch('box_1_a')

--- a/test/rebalancer/rebalancer.test.lua
+++ b/test/rebalancer/rebalancer.test.lua
@@ -48,11 +48,11 @@ wait_rebalancer_state('Total active bucket count is not equal to total', test_ru
 vshard.storage.rebalancer_disable()
 cfg.rebalancer_max_receiving = 10
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('box_2_a')
 _bucket = box.space._bucket
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 
 test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
@@ -64,7 +64,7 @@ wait_rebalancer_state("The cluster is balanced ok", test_run)
 --
 vshard.storage.rebalancer_disable()
 test_run:switch('box_2_a')
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('default')
 util.map_evals(test_run, {REPLICASET_1},                                        \
@@ -98,7 +98,7 @@ test_run:switch('box_1_a')
 cfg.rebalancer_disbalance_threshold = 300
 vshard.storage.rebalancer_disable()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 
 test_run:switch('default')
 util.map_evals(test_run, {REPLICASET_2},                                        \
@@ -160,7 +160,8 @@ _bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 -- (See point (7) in the test plan)
 --
 vshard.storage.rebalancer_disable()
-for i = 91, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+wait_bucket_is_collected(100)
+vshard.storage.bucket_force_create(91, 10)
 space = box.space.test
 space:replace{1, 91}
 space:replace{2, 92}

--- a/test/rebalancer/rebalancer_lock_and_pin.result
+++ b/test/rebalancer/rebalancer_lock_and_pin.result
@@ -440,6 +440,17 @@ box.space._bucket:get{first_id}.status
 ---
 - active
 ...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
+test_run:switch('box_1_a')
+---
+- true
+...
 -- Test that can not pin other buckets.
 test_run:cmd("setopt delimiter ';'")
 ---
@@ -470,10 +481,25 @@ box.rollback()
 test_run:cmd("setopt delimiter ''");
 ---
 ...
+vshard.storage.sync()
+---
+- true
+...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
 --
 -- gh-189: a pinned bucket can't be sent. Unpin is required
 -- beforehand.
 --
+test_run:switch('box_1_a')
+---
+- true
+...
 vshard.storage.bucket_pin(first_id)
 ---
 - true

--- a/test/rebalancer/rebalancer_lock_and_pin.test.lua
+++ b/test/rebalancer/rebalancer_lock_and_pin.test.lua
@@ -183,6 +183,10 @@ box.space._bucket:get{first_id}.status
 vshard.storage.bucket_unpin(first_id)
 box.space._bucket:get{first_id}.status
 
+test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+
+test_run:switch('box_1_a')
 -- Test that can not pin other buckets.
 test_run:cmd("setopt delimiter ';'")
 box.begin()
@@ -208,11 +212,16 @@ ok, err = vshard.storage.bucket_unpin(first_id)
 assert(not ok and err)
 box.rollback()
 test_run:cmd("setopt delimiter ''");
+vshard.storage.sync()
+
+test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 
 --
 -- gh-189: a pinned bucket can't be sent. Unpin is required
 -- beforehand.
 --
+test_run:switch('box_1_a')
 vshard.storage.bucket_pin(first_id)
 vshard.storage.bucket_send(first_id, util.replicasets[2])
 vshard.storage.bucket_unpin(first_id)

--- a/test/rebalancer/receiving_bucket.result
+++ b/test/rebalancer/receiving_bucket.result
@@ -38,8 +38,9 @@ _ = test_run:switch('box_1_a')
 _bucket = box.space._bucket
 ---
 ...
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 ---
+- true
 ...
 _ = test_run:switch('box_2_a')
 ---
@@ -47,8 +48,9 @@ _ = test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 ---
+- true
 ...
 create_simple_space('test3', {engine = 'vinyl'})
 ---

--- a/test/rebalancer/receiving_bucket.test.lua
+++ b/test/rebalancer/receiving_bucket.test.lua
@@ -18,11 +18,11 @@ util.push_rs_filters(test_run)
 
 _ = test_run:switch('box_1_a')
 _bucket = box.space._bucket
-for i = 1, 100 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 
 _ = test_run:switch('box_2_a')
 _bucket = box.space._bucket
-for i = 101, 200 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 create_simple_space('test3', {engine = 'vinyl'})
 create_simple_space('test4')
 create_simple_space('test5', {engine = 'vinyl'})

--- a/test/rebalancer/restart_during_rebalancing.result
+++ b/test/rebalancer/restart_during_rebalancing.result
@@ -89,8 +89,9 @@ vshard.storage.rebalancer_disable()
 log.info(string.rep('a', 1000))
 ---
 ...
-for i = 1, 200 do box.space._bucket:replace({i, vshard.consts.BUCKET.ACTIVE}) end
+vshard.storage.bucket_force_create(1, 200)
 ---
+- true
 ...
 test_run:switch('router_1')
 ---

--- a/test/rebalancer/restart_during_rebalancing.test.lua
+++ b/test/rebalancer/restart_during_rebalancing.test.lua
@@ -38,7 +38,7 @@ vshard.router.cfg(cfg)
 test_run:switch('fullbox_1_a')
 vshard.storage.rebalancer_disable()
 log.info(string.rep('a', 1000))
-for i = 1, 200 do box.space._bucket:replace({i, vshard.consts.BUCKET.ACTIVE}) end
+vshard.storage.bucket_force_create(1, 200)
 
 test_run:switch('router_1')
 for i = 1, 4 do vshard.router.discovery_wakeup() end

--- a/test/rebalancer/stress_add_remove_rs.result
+++ b/test/rebalancer/stress_add_remove_rs.result
@@ -56,8 +56,9 @@ test_run:switch('box_2_a')
 ---
 - true
 ...
-for i = 1, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 200)
 ---
+- true
 ...
 test_run:switch('box_1_a')
 ---

--- a/test/rebalancer/stress_add_remove_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_rs.test.lua
@@ -26,7 +26,8 @@ test_run:switch('router_1')
 -- data, that were written during the step execution.
 --
 test_run:switch('box_2_a')
-for i = 1, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 200)
+
 test_run:switch('box_1_a')
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 wait_rebalancer_state('The cluster is balanced ok', test_run)

--- a/test/rebalancer/stress_add_remove_several_rs.result
+++ b/test/rebalancer/stress_add_remove_several_rs.result
@@ -66,8 +66,9 @@ cfg.rebalancer_max_receiving = 2
 vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
 ---
 ...
-for i = 1, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 200)
 ---
+- true
 ...
 test_run:switch('box_1_a')
 ---

--- a/test/rebalancer/stress_add_remove_several_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_several_rs.test.lua
@@ -31,7 +31,7 @@ test_run:switch('router_1')
 test_run:switch('box_2_a')
 cfg.rebalancer_max_receiving = 2
 vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
-for i = 1, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 200)
 
 test_run:switch('box_1_a')
 cfg.rebalancer_max_receiving = 2

--- a/test/reload_evolution/storage.result
+++ b/test/reload_evolution/storage.result
@@ -53,6 +53,13 @@ vshard.storage.bucket_force_create(1, vshard.consts.DEFAULT_BUCKET_COUNT / 2)
 bucket_id_to_move = vshard.consts.DEFAULT_BUCKET_COUNT
 ---
 ...
+test_run:switch('storage_2_b')
+---
+- true
+...
+vshard.storage.internal.is_bucket_protected = false
+---
+...
 test_run:switch('storage_2_a')
 ---
 - true
@@ -105,9 +112,15 @@ vshard.storage.internal.reload_version
 - 1
 ...
 -- Make sure storage operates well.
+vshard.storage.internal.is_bucket_protected = false
+---
+...
 vshard.storage.bucket_force_drop(2000)
 ---
 - true
+...
+vshard.storage.internal.is_bucket_protected = true
+---
 ...
 vshard.storage.bucket_force_create(2000)
 ---
@@ -176,7 +189,13 @@ assert(move_start + move_cnt < vshard.consts.DEFAULT_BUCKET_COUNT)
 ---
 - true
 ...
+vshard.storage.internal.is_bucket_protected = false
+---
+...
 for i = move_start, move_start + move_cnt - 1 do box.space._bucket:delete{i} end
+---
+...
+vshard.storage.internal.is_bucket_protected = true
 ---
 ...
 box.space._bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})

--- a/test/reload_evolution/storage.test.lua
+++ b/test/reload_evolution/storage.test.lua
@@ -23,6 +23,9 @@ test_run:switch('storage_1_a')
 vshard.storage.bucket_force_create(1, vshard.consts.DEFAULT_BUCKET_COUNT / 2)
 bucket_id_to_move = vshard.consts.DEFAULT_BUCKET_COUNT
 
+test_run:switch('storage_2_b')
+vshard.storage.internal.is_bucket_protected = false
+
 test_run:switch('storage_2_a')
 vshard.storage.bucket_force_create(vshard.consts.DEFAULT_BUCKET_COUNT / 2 + 1, vshard.consts.DEFAULT_BUCKET_COUNT / 2)
 bucket_id_to_move = vshard.consts.DEFAULT_BUCKET_COUNT
@@ -46,7 +49,9 @@ vshard.storage.internal.reload_version
 #box.space._bucket:on_replace()
 
 -- Make sure storage operates well.
+vshard.storage.internal.is_bucket_protected = false
 vshard.storage.bucket_force_drop(2000)
+vshard.storage.internal.is_bucket_protected = true
 vshard.storage.bucket_force_create(2000)
 vshard.storage.buckets_info()[2000]
 vshard.storage.call(bucket_id_to_move, 'read', 'do_select', {42})
@@ -69,7 +74,9 @@ vshard.storage.rebalancer_disable()
 move_start = vshard.consts.DEFAULT_BUCKET_COUNT / 2 + 1
 move_cnt = 100
 assert(move_start + move_cnt < vshard.consts.DEFAULT_BUCKET_COUNT)
+vshard.storage.internal.is_bucket_protected = false
 for i = move_start, move_start + move_cnt - 1 do box.space._bucket:delete{i} end
+vshard.storage.internal.is_bucket_protected = true
 box.space._bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 test_run:switch('storage_1_a')
 move_start = vshard.consts.DEFAULT_BUCKET_COUNT / 2 + 1

--- a/test/router/map-reduce.result
+++ b/test/router/map-reduce.result
@@ -388,6 +388,14 @@ test_run:wait_cond(function() return lref.count == 0 end)
 -- Fail if some buckets are not visible. Even if all the known replicasets were
 -- scanned. It means consistency violation.
 --
+test_run:switch('default')
+ | ---
+ | - true
+ | ...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+ | ---
+ | ...
+
 _ = test_run:switch('storage_1_a')
  | ---
  | ...
@@ -397,6 +405,18 @@ bucket_id = box.space._bucket.index.pk:min().id
 vshard.storage.bucket_force_drop(bucket_id)
  | ---
  | - true
+ | ...
+vshard.storage.sync()
+ | ---
+ | - true
+ | ...
+
+test_run:switch('default')
+ | ---
+ | - true
+ | ...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+ | ---
  | ...
 
 _ = test_run:switch('router_1')
@@ -422,6 +442,14 @@ vshard.storage.bucket_force_create(bucket_id)
  | - true
  | ...
 
+test_run:switch('default')
+ | ---
+ | - true
+ | ...
+util.map_bucket_protection(test_run, {REPLICASET_2}, false)
+ | ---
+ | ...
+
 _ = test_run:switch('storage_2_a')
  | ---
  | ...
@@ -435,6 +463,18 @@ bucket_id = box.space._bucket.index.pk:min().id
 vshard.storage.bucket_force_drop(bucket_id)
  | ---
  | - true
+ | ...
+vshard.storage.sync()
+ | ---
+ | - true
+ | ...
+
+test_run:switch('default')
+ | ---
+ | - true
+ | ...
+util.map_bucket_protection(test_run, {REPLICASET_2}, true)
+ | ---
  | ...
 
 _ = test_run:switch('router_1')

--- a/test/router/reconnect_to_master.result
+++ b/test/router/reconnect_to_master.result
@@ -34,8 +34,9 @@ _ = test_run:switch('storage_1_a')
 _bucket = box.space._bucket
 ---
 ...
-for i = 1, 10 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 10)
 ---
+- true
 ...
 _ = test_run:switch('storage_1_b')
 ---

--- a/test/router/reconnect_to_master.test.lua
+++ b/test/router/reconnect_to_master.test.lua
@@ -16,7 +16,8 @@ util.wait_master(test_run, REPLICASET_2, 'storage_2_a')
 --
 _ = test_run:switch('storage_1_a')
 _bucket = box.space._bucket
-for i = 1, 10 do _bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 10)
+
 _ = test_run:switch('storage_1_b')
 _bucket = box.space._bucket
 while _bucket:count() ~= 10 do fiber.sleep(0.1) end

--- a/test/router/reroute_wrong_bucket.result
+++ b/test/router/reroute_wrong_bucket.result
@@ -46,8 +46,9 @@ vshard.storage.cfg(cfg, util.name_to_uuid.storage_1_a)
 vshard.storage.rebalancer_disable()
 ---
 ...
-for i = 1, 100 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 ---
+- true
 ...
 test_run:switch('storage_2_a')
 ---
@@ -62,8 +63,9 @@ vshard.storage.cfg(cfg, util.name_to_uuid.storage_2_a)
 vshard.storage.rebalancer_disable()
 ---
 ...
-for i = 101, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 ---
+- true
 ...
 test_run:switch('router_1')
 ---
@@ -88,9 +90,9 @@ test_run:switch('storage_2_a')
 ---
 - true
 ...
-box.space._bucket:replace{100, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(100)
 ---
-- [100, 'active']
+- true
 ...
 box.space.test:insert{1, 100}
 ---

--- a/test/router/reroute_wrong_bucket.result
+++ b/test/router/reroute_wrong_bucket.result
@@ -33,6 +33,9 @@ test_run:cmd('start server router_1')
 ---
 - true
 ...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, false)
+---
+...
 test_run:switch('storage_1_a')
 ---
 - true
@@ -140,6 +143,10 @@ box.space._bucket:replace({100, vshard.consts.BUCKET.ACTIVE})
 ---
 - [100, 'active']
 ...
+vshard.storage.sync()
+---
+- true
+...
 test_run:switch('storage_1_a')
 ---
 - true
@@ -147,6 +154,17 @@ test_run:switch('storage_1_a')
 box.space._bucket:replace({100, vshard.consts.BUCKET.SENT, util.replicasets[2]})
 ---
 - [100, 'sent', 'ac522f65-aa94-4134-9f64-51ee384f1a54']
+...
+vshard.storage.sync()
+---
+- true
+...
+test_run:switch('default')
+---
+- true
+...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, true)
+---
 ...
 test_run:switch('router_1')
 ---

--- a/test/router/reroute_wrong_bucket.test.lua
+++ b/test/router/reroute_wrong_bucket.test.lua
@@ -14,13 +14,13 @@ test_run:switch('storage_1_a')
 vshard.consts.BUCKET_SENT_GARBAGE_DELAY = 100
 vshard.storage.cfg(cfg, util.name_to_uuid.storage_1_a)
 vshard.storage.rebalancer_disable()
-for i = 1, 100 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('storage_2_a')
 vshard.consts.BUCKET_SENT_GARBAGE_DELAY = 100
 vshard.storage.cfg(cfg, util.name_to_uuid.storage_2_a)
 vshard.storage.rebalancer_disable()
-for i = 101, 200 do box.space._bucket:replace{i, vshard.consts.BUCKET.ACTIVE} end
+vshard.storage.bucket_force_create(101, 100)
 
 test_run:switch('router_1')
 util = require('util')
@@ -30,7 +30,7 @@ test_run:switch('storage_1_a')
 box.space._bucket:update({100}, {{'=', 2, vshard.consts.BUCKET.SENT}, {'=', 3, util.replicasets[2]}})
 
 test_run:switch('storage_2_a')
-box.space._bucket:replace{100, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(100)
 box.space.test:insert{1, 100}
 
 test_run:switch('router_1')

--- a/test/router/router.result
+++ b/test/router/router.result
@@ -348,6 +348,12 @@ util.check_error(vshard.router.call, 1, 'write', 'echo', {123})
   name: TRANSFER_IS_IN_PROGRESS
   message: Bucket 1 is transferring to replicaset <replicaset_1>
 ...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
 _ = test_run:switch('storage_1_a')
 ---
 ...
@@ -356,6 +362,16 @@ box.space._bucket:delete({1})
 - [1, 'receiving', '<replicaset_2>']
 ...
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
+---
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 ---
 ...
 _ = test_run:switch('storage_2_a')

--- a/test/router/router.test.lua
+++ b/test/router/router.test.lua
@@ -129,9 +129,16 @@ vshard.router.call(1, 'read', 'echo', {123})
 -- Not ok to write sending bucket.
 util.check_error(vshard.router.call, 1, 'write', 'echo', {123})
 
+_ = test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+
 _ = test_run:switch('storage_1_a')
 box.space._bucket:delete({1})
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false
+vshard.storage.sync()
+
+_ = test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 
 _ = test_run:switch('storage_2_a')
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = false

--- a/test/storage-luatest/garbage_collector_test.lua
+++ b/test/storage-luatest/garbage_collector_test.lua
@@ -15,6 +15,10 @@ end
 
 local test_group = t.group('bucket_gc', group_config)
 
+local function bucket_set_protection(value)
+    ivshard.storage.internal.is_bucket_protected = value
+end
+
 local cfg_template = {
     sharding = {
         {
@@ -59,6 +63,7 @@ end)
 -- Fill a few buckets, "send" them, ensure they and their data are gone.
 --
 test_group.test_basic = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function()
         local bucket_space = box.space._bucket
         local status_index = bucket_space.index.status
@@ -96,12 +101,14 @@ test_group.test_basic = function(g)
 
         -- Simulate sending of some buckets.
         local sent_bids = {}
+        ivshard.storage.internal.is_bucket_protected = false
         for i, bid in pairs(all_bids) do
             if i % 3 == 0 then
                 table.insert(sent_bids, bid)
                 bucket_space:update({bid}, {{'=', 2, ivconst.BUCKET.SENT}})
             end
         end
+        ivshard.storage.internal.is_bucket_protected = true
         ilt.assert(#sent_bids > 0, 'sent some buckets')
 
         -- The master has GC fiber.
@@ -144,6 +151,7 @@ test_group.test_basic = function(g)
 
     -- Ensure the replica received all that and didn't break in the middle.
     g.replica_1_b:wait_vclock_of(g.replica_1_a)
+    g.replica_1_b:exec(bucket_set_protection, {true})
     g.replica_1_b:exec(function()
         -- Non-master doesn't have a GC bucket.
         ilt.assert_equals(
@@ -153,6 +161,7 @@ end
 
 test_group.test_yield_before_send_commit = function(g)
     t.run_only_if(global_cfg.memtx_use_mvcc_engine)
+    g.replica_1_b:exec(bucket_set_protection, {false})
 
     g.replica_1_a:exec(function()
         local s = box.space.test
@@ -172,7 +181,9 @@ test_group.test_yield_before_send_commit = function(g)
         local is_send_blocked = true
         local f_send = ifiber.new(function()
             box.begin()
+            ivshard.storage.internal.is_bucket_protected = false
             bucket_space:update({bid}, {{'=', 2, ivconst.BUCKET.SENT}})
+            ivshard.storage.internal.is_bucket_protected = true
             while is_send_blocked do
                 ifiber.sleep(0.01)
             end
@@ -197,6 +208,7 @@ test_group.test_yield_before_send_commit = function(g)
 
     -- Ensure the replica received all that and didn't break.
     g.replica_1_b:wait_vclock_of(g.replica_1_a)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
@@ -207,6 +219,7 @@ test_group.test_fail_bucket_space_replace = function(g)
     --
     -- A couple of buckets. One becomes SENT but all deletions in _bucket fail.
     --
+    g.replica_1_b:exec(bucket_set_protection, {false})
     local bid1_active, bid2_sent = g.replica_1_a:exec(function()
         local _bucket = box.space._bucket
         local bstatus = ivconst.BUCKET
@@ -227,7 +240,9 @@ test_group.test_fail_bucket_space_replace = function(g)
         s:replace{3, bid1_active}
         s:replace{4, bid2_sent}
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid2_sent, ivconst.BUCKET.SENT}
+        ivshard.storage.internal.is_bucket_protected = true
         -- Flush garbage into the logs to separate the next greps from the old
         -- logs.
         require('log').info(string.rep('a', 1000))
@@ -268,12 +283,16 @@ test_group.test_fail_bucket_space_replace = function(g)
         -- Cleanup.
         --
         s:truncate()
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid2_sent, ivconst.BUCKET.ACTIVE}
+        ivshard.storage.internal.is_bucket_protected = true
         local bucket_count = total_bucket_count
         ilt.assert_equals(_bucket:count(), bucket_count)
         ilt.assert_equals(_bucket.index.status:count(ivconst.BUCKET.ACTIVE),
                           bucket_count)
     end, {bid1_active, bid2_sent})
+    vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
@@ -281,6 +300,7 @@ end
 -- everything with yields in between.
 --
 test_group.test_huge_bucket_count = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function(engine)
         ilt.assert_not_equals(engine, nil)
         local _bucket = box.space._bucket
@@ -326,6 +346,7 @@ test_group.test_huge_bucket_count = function(g)
         --
         -- Simulate buckets' sending.
         --
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for bid = 1, bucket_count_new do
             if bid % ivconst.BUCKET_CHUNK_SIZE == 0 then
@@ -339,6 +360,7 @@ test_group.test_huge_bucket_count = function(g)
             end
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
 
         _G.bucket_gc_continue()
         _G.bucket_gc_wait()
@@ -351,13 +373,16 @@ test_group.test_huge_bucket_count = function(g)
         ivconst.BUCKET_CHUNK_SIZE = old_chunk_size
         s1:drop()
         s2:drop()
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for bid = 1, bucket_count_old do
             _bucket:replace{bid, ivconst.BUCKET.ACTIVE}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
     end, {g.params.engine})
     vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
@@ -386,6 +411,7 @@ test_group.test_replica_ref_basic = function(g)
     --
     -- Master tries to GC the buckets, but it can't.
     --
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function(bids)
         local _bucket = box.space._bucket
         local s = box.space.test
@@ -395,11 +421,13 @@ test_group.test_replica_ref_basic = function(g)
             s:replace{bid, bid}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for _, bid in ipairs(bids) do
             _bucket:replace{bid, ivconst.BUCKET.SENT}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
 
         _G.bucket_gc_once()
         for _, bid in ipairs(bids) do
@@ -409,6 +437,8 @@ test_group.test_replica_ref_basic = function(g)
             ilt.assert_equals(s:get{bid}, {bid, bid})
         end
     end, {bids})
+    vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
     --
     -- Free some refs on the replica but not all.
     --
@@ -485,7 +515,9 @@ test_group.test_replica_ref_bucket_wait_lsn = function(g)
         local s = box.space.test
 
         s:replace{bid, bid}
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid, ivconst.BUCKET.SENT}
+        ivshard.storage.internal.is_bucket_protected = true
         ivshard.storage.garbage_collector_wakeup()
         ifiber.sleep(0.1)
 
@@ -499,6 +531,9 @@ test_group.test_replica_ref_bucket_wait_lsn = function(g)
     -- Restore the replication.
     --
     g.replica_1_b:exec(function()
+        -- Disable the protection because will now receive active->sent
+        -- transition from the master.
+        ivshard.storage.internal.is_bucket_protected = false
         box.cfg{replication = _G.old_replication}
         _G.old_replication = nil
     end)
@@ -516,6 +551,7 @@ test_group.test_replica_ref_bucket_wait_lsn = function(g)
         ivshard.storage.bucket_force_create(bid)
     end, {bid})
     vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
@@ -524,6 +560,7 @@ end
 -- should be ready.
 --
 test_group.test_local_changes_during_replicas_check = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function()
         local _bucket = box.space._bucket
         local bids_part1 = {1, 3, 5}
@@ -536,11 +573,13 @@ test_group.test_local_changes_during_replicas_check = function(g)
 
         local errinj = ivshard.storage.internal.errinj
         errinj.ERRINJ_BUCKET_GC_LONG_REPLICAS_TEST = true
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for _, bid in ipairs(bids) do
             _bucket:replace{bid, ivconst.BUCKET.SENT}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
         ivshard.storage.garbage_collector_wakeup()
         ifiber.yield()
         --
@@ -548,6 +587,7 @@ test_group.test_local_changes_during_replicas_check = function(g)
         -- the master come back to life: get new refs or change status. They
         -- should remain.
         --
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for _, bid in ipairs(bids_part2) do
             _bucket:replace{bid, ivconst.BUCKET.ACTIVE}
@@ -560,6 +600,7 @@ test_group.test_local_changes_during_replicas_check = function(g)
             _bucket:replace{bid, ivconst.BUCKET.SENT}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
         errinj.ERRINJ_BUCKET_GC_LONG_REPLICAS_TEST = false
         ivshard.storage.garbage_collector_wakeup()
         -- Run GC twice - first time to end the current run. Second time to
@@ -592,19 +633,23 @@ test_group.test_local_changes_during_replicas_check = function(g)
         --
         -- Cleanup.
         --
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for _, bid in ipairs(bids) do
             _bucket:replace{bid, ivconst.BUCKET.ACTIVE}
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
     end)
     vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
 -- Unit tests for gc_bucket_drop() internal function.
 --
 test_group.test_unit_gc_bucket_drop = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function(engine)
         ilt.assert_not_equals(engine, nil)
         local _bucket = box.space._bucket
@@ -685,11 +730,13 @@ test_group.test_unit_gc_bucket_drop = function(g)
             end
             box.commit()
 
+            ivshard.storage.internal.is_bucket_protected = false
             _bucket:replace{bid2_receiving, bstatus.RECEIVING}
             _bucket:replace{bid4_sent, bstatus.SENT, 'destination1'}
             _bucket:replace{bid5_garbage, bstatus.GARBAGE}
             _bucket:replace{bid6_garbage, bstatus.GARBAGE, 'destination2'}
             _bucket:replace{bid8_garbage, bstatus.GARBAGE}
+            ivshard.storage.internal.is_bucket_protected = true
             ilt.assert_equals(_bucket:count(), total_bucket_count)
         end
 
@@ -725,7 +772,9 @@ test_group.test_unit_gc_bucket_drop = function(g)
         --
         route_map = {}
         bucket_count = bucket_count - _bucket_idx_status:count(bstatus.SENT)
+        ivshard.storage.internal.is_bucket_protected = false
         ilt.assert(gc_bucket_drop(bstatus.SENT, route_map))
+        ivshard.storage.internal.is_bucket_protected = true
         ilt.assert_equals(route_map, {[bid4_sent] = 'destination1'})
         ilt.assert_equals(_bucket:count(), bucket_count)
         ilt.assert_equals(_bucket.index.status:select(bstatus.SENT), {})
@@ -735,7 +784,9 @@ test_group.test_unit_gc_bucket_drop = function(g)
         --
         route_map = {}
         ilt.assert(gc_bucket_drop(bstatus.GARBAGE, route_map))
+        ivshard.storage.internal.is_bucket_protected = false
         ilt.assert(gc_bucket_drop(bstatus.SENT, route_map))
+        ivshard.storage.internal.is_bucket_protected = true
         ilt.assert_equals(_bucket:count(), bucket_count)
         ilt.assert_equals(route_map, {})
         data_validate()
@@ -757,22 +808,27 @@ test_group.test_unit_gc_bucket_drop = function(g)
         --
         s1:drop()
         s2:drop()
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid2_receiving, bstatus.ACTIVE}
         _bucket:replace{bid4_sent, bstatus.ACTIVE}
         _bucket:replace{bid5_garbage, bstatus.ACTIVE}
         _bucket:replace{bid6_garbage, bstatus.ACTIVE}
         _bucket:replace{bid8_garbage, bstatus.ACTIVE}
+        ivshard.storage.internal.is_bucket_protected = true
         ilt.assert_equals(_bucket:count(), total_bucket_count)
         ilt.assert_equals(_bucket.index.status:count(bstatus.ACTIVE),
                           total_bucket_count)
         _G.bucket_recovery_continue()
     end, {g.params.engine})
+    vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
 -- Unit tests for vshard.storage.bucket_delete_garbage().
 --
 test_group.test_unit_bucket_delete_garbage = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function(engine)
         ilt.assert_not_equals(engine, nil)
         local _bucket = box.space._bucket
@@ -803,7 +859,9 @@ test_group.test_unit_bucket_delete_garbage = function(g)
 
         -- Delete an existing garbage bucket.
         data_prepare()
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid2, ivconst.BUCKET.GARBAGE}
+        ivshard.storage.internal.is_bucket_protected = true
         delete_garbage(bid2)
         ilt.assert_equals(s:select{}, {{1, bid1}, {3, bid1}})
 
@@ -816,7 +874,9 @@ test_group.test_unit_bucket_delete_garbage = function(g)
         -- Fail to delete a not garbage bucket.
         data_prepare()
         ilt.assert_equals(s:count(), 4)
+        ivshard.storage.internal.is_bucket_protected = false
         _bucket:replace{bid2, ivconst.BUCKET.ACTIVE}
+        ivshard.storage.internal.is_bucket_protected = false
         ilt.assert_error_msg_contains('Can not delete not garbage bucket',
                                       delete_garbage, bid2)
         -- tarantool/gh-7394: space:count() is broken here when mvcc is used. It
@@ -838,12 +898,15 @@ test_group.test_unit_bucket_delete_garbage = function(g)
         _G.bucket_recovery_continue()
         _G.bucket_gc_continue()
     end, {g.params.engine})
+    vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end
 
 --
 -- Unit tests for vshard.storage._call('bucket_test_gc').
 --
 test_group.test_unit_bucket_test_gc = function(g)
+    g.replica_1_b:exec(bucket_set_protection, {false})
     g.replica_1_a:exec(function()
         local bucket_count = ivshard.storage.internal.total_bucket_count
         local _bucket = box.space._bucket
@@ -882,6 +945,7 @@ test_group.test_unit_bucket_test_gc = function(g)
         ivutil.table_extend(not_ok_bids, receiving_bids)
         ivutil.table_extend(not_ok_bids, active_bids)
 
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for _, bid in ipairs(sent_ro_bids) do
             ilt.assert(ivshard.storage.bucket_refro(bid))
@@ -896,6 +960,7 @@ test_group.test_unit_bucket_test_gc = function(g)
             _bucket:update({bid}, {{'=', 2, ivconst.BUCKET.RECEIVING}})
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
         --
         -- All is available for GC.
         --
@@ -913,9 +978,11 @@ test_group.test_unit_bucket_test_gc = function(g)
         for _, bid in ipairs(sent_ro_bids) do
             ilt.assert(ivshard.storage.bucket_unrefro(bid))
         end
+        ivshard.storage.internal.is_bucket_protected = false
         for _, bid in ipairs(test_bids) do
             _bucket:update({bid}, {{'=', 2, ivconst.BUCKET.ACTIVE}})
         end
+        ivshard.storage.internal.is_bucket_protected = true
         box.commit()
         --
         -- Long bucket list iteration should yield.
@@ -927,6 +994,7 @@ test_group.test_unit_bucket_test_gc = function(g)
         ilt.assert_gt(bucket_count_new, bucket_count)
         sent_bids = {}
         sent_ro_bids = {}
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for i = 1, bucket_count_new do
             _bucket:replace({i, ivconst.BUCKET.ACTIVE})
@@ -940,6 +1008,7 @@ test_group.test_unit_bucket_test_gc = function(g)
             end
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
         if ivutil.feature.csw then
             local csw1 = ifiber.self():csw()
             ilt.assert_equals(test_gc(sent_bids), sent_ro_bids)
@@ -955,6 +1024,7 @@ test_group.test_unit_bucket_test_gc = function(g)
         for _, bid in ipairs(sent_ro_bids) do
             ilt.assert(ivshard.storage.bucket_unrefro(bid))
         end
+        ivshard.storage.internal.is_bucket_protected = false
         box.begin()
         for bid = 1, bucket_count do
             _bucket:replace({bid, ivconst.BUCKET.ACTIVE})
@@ -963,8 +1033,10 @@ test_group.test_unit_bucket_test_gc = function(g)
             _bucket:delete({bid})
         end
         box.commit()
+        ivshard.storage.internal.is_bucket_protected = true
         _G.bucket_recovery_continue()
         _G.bucket_gc_continue()
     end)
     vtest.cluster_wait_vclock_all(g)
+    g.replica_1_b:exec(bucket_set_protection, {true})
 end

--- a/test/storage-luatest/storage_2_test.lua
+++ b/test/storage-luatest/storage_2_test.lua
@@ -113,10 +113,10 @@ local function test_storage_callro_refro_loss(g, user_err)
 
     -- The bucket becomes deleted on the master due to any reason. Need to pause
     -- the protection. Otherwise the replica would reject the bucket drop.
-    rep_b:exec(bucket_set_protection, {false})
+    vtest.cluster_exec_each(g, bucket_set_protection, {false})
     rep_a:exec(bucket_force_drop, {bid})
     rep_b:wait_vclock_of(rep_a)
-    rep_b:exec(bucket_set_protection, {true})
+    vtest.cluster_exec_each(g, bucket_set_protection, {true})
     rep_b:exec(bucket_check_no_ref, {bid})
 
     -- The replica should fail to complete the RO request.
@@ -168,10 +168,11 @@ local function test_storage_callro_refrw_loss(g, user_err)
     -- The bucket becomes deleted on the new master due to any reason. Need to
     -- pause the protection. Otherwise the old master would reject the bucket
     -- drop.
-    rep_a:exec(bucket_set_protection, {false})
+    vtest.cluster_exec_each(g, bucket_set_protection, {false})
     rep_b:exec(bucket_force_drop, {bid})
     rep_a:wait_vclock_of(rep_b)
-    rep_a:exec(bucket_set_protection, {true})
+    rep_a:wait_vclock_of(rep_a)
+    vtest.cluster_exec_each(g, bucket_set_protection, {true})
     rep_a:exec(bucket_check_no_ref, {bid})
 
     -- The old master should fail to complete the RW request.

--- a/test/storage/recovery.result
+++ b/test/storage/recovery.result
@@ -36,7 +36,13 @@ vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 vshard.storage.rebalancer_disable()
 ---
 ...
-_ = test_run:switch("storage_1_a")
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
+_ = test_run:switch('storage_1_a')
 ---
 ...
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
@@ -56,6 +62,19 @@ _bucket:replace{3, vshard.consts.BUCKET.RECEIVING, util.replicasets[2]}
 ---
 - [3, 'receiving', '<replicaset_2>']
 ...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_2}, false)
+---
+...
 _ = test_run:switch('storage_2_a')
 ---
 ...
@@ -69,6 +88,16 @@ vshard.storage.bucket_force_create(2)
 _bucket:replace{3, vshard.consts.BUCKET.SENDING, util.replicasets[1]}
 ---
 - [3, 'sending', '<replicaset_1>']
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_2}, true)
+---
 ...
 _ = test_run:cmd('stop server storage_1_a')
 ---
@@ -119,6 +148,12 @@ while _bucket:count() ~= 2 do vshard.storage.recovery_wakeup() fiber.sleep(0.1) 
 -- Test a case, when a destination is down. The recovery fiber
 -- must restore buckets, when the destination is up.
 --
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
 _ = test_run:switch('storage_1_a')
 ---
 ...
@@ -129,6 +164,10 @@ _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 ---
 - [1, 'sending', '<replicaset_2>']
 ...
+vshard.storage.sync()
+---
+- true
+...
 _ = test_run:switch('storage_2_a')
 ---
 ...
@@ -136,7 +175,14 @@ vshard.storage.bucket_force_create(1)
 ---
 - true
 ...
+vshard.storage.sync()
+---
+- true
+...
 _ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 ---
 ...
 _ = test_run:cmd('stop server storage_2_a')
@@ -191,9 +237,22 @@ _bucket:select{}
 -- Test a case when a bucket is sending in one place and garbage
 -- or sent or deleted on a destination.
 --
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, false)
+---
+...
+_ = test_run:switch('storage_2_a')
+---
+...
 _bucket:replace{1, vshard.consts.BUCKET.GARBAGE, util.replicasets[1]}
 ---
 - [1, 'garbage', '<replicaset_1>']
+...
+vshard.storage.sync()
+---
+- true
 ...
 _ = test_run:switch('storage_1_a')
 ---
@@ -201,6 +260,16 @@ _ = test_run:switch('storage_1_a')
 _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 ---
 - [1, 'sending', '<replicaset_2>']
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, true)
+---
 ...
 _ = test_run:switch('default')
 ---

--- a/test/storage/recovery.result
+++ b/test/storage/recovery.result
@@ -62,9 +62,9 @@ _ = test_run:switch('storage_2_a')
 _bucket = box.space._bucket
 ---
 ...
-_bucket:replace{2, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(2)
 ---
-- [2, 'active']
+- true
 ...
 _bucket:replace{3, vshard.consts.BUCKET.SENDING, util.replicasets[1]}
 ---
@@ -132,9 +132,9 @@ _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 _ = test_run:switch('storage_2_a')
 ---
 ...
-_bucket:replace{1, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(1)
 ---
-- [1, 'active']
+- true
 ...
 _ = test_run:switch('default')
 ---

--- a/test/storage/recovery.test.lua
+++ b/test/storage/recovery.test.lua
@@ -28,7 +28,7 @@ _bucket:replace{3, vshard.consts.BUCKET.RECEIVING, util.replicasets[2]}
 
 _ = test_run:switch('storage_2_a')
 _bucket = box.space._bucket
-_bucket:replace{2, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(2)
 _bucket:replace{3, vshard.consts.BUCKET.SENDING, util.replicasets[1]}
 
 _ = test_run:cmd('stop server storage_1_a')
@@ -61,7 +61,7 @@ _ = test_run:switch('storage_1_a')
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 _bucket:replace{1, vshard.consts.BUCKET.SENDING, util.replicasets[2]}
 _ = test_run:switch('storage_2_a')
-_bucket:replace{1, vshard.consts.BUCKET.ACTIVE}
+vshard.storage.bucket_force_create(1)
 _ = test_run:switch('default')
 _ = test_run:cmd('stop server storage_2_a')
 _ = test_run:cmd('stop server storage_1_a')

--- a/test/storage/recovery_errinj.result
+++ b/test/storage/recovery_errinj.result
@@ -40,6 +40,12 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 ---
 ...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
 _ = test_run:switch('storage_1_a')
 ---
 ...
@@ -52,6 +58,19 @@ _bucket = box.space._bucket
 _bucket:replace{1, vshard.consts.BUCKET.ACTIVE, util.replicasets[2]}
 ---
 - [1, 'active', '<replicaset_2>']
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
+_ = test_run:switch('storage_1_a')
+---
 ...
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
 ---

--- a/test/storage/recovery_errinj.test.lua
+++ b/test/storage/recovery_errinj.test.lua
@@ -18,10 +18,19 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 -- simulate the intermediate state.
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 
+_ = test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+
 _ = test_run:switch('storage_1_a')
 vshard.storage.internal.errinj.ERRINJ_RECOVERY_PAUSE = true
 _bucket = box.space._bucket
 _bucket:replace{1, vshard.consts.BUCKET.ACTIVE, util.replicasets[2]}
+vshard.storage.sync()
+
+_ = test_run:switch('default')
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+
+_ = test_run:switch('storage_1_a')
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
 ret, util.is_timeout_error(err)
 _bucket = box.space._bucket

--- a/test/storage/storage.result
+++ b/test/storage/storage.result
@@ -186,7 +186,31 @@ assert(not ok and err.message:match("Duplicate key exists"))
 ---
 - Duplicate key exists
 ...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
+test_run:switch('storage_1_a')
+---
+- true
+...
 vshard.storage.bucket_force_drop(1)
+---
+- true
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
+test_run:switch('storage_1_a')
 ---
 - true
 ...
@@ -727,6 +751,12 @@ rs:callro('echo', {'some_data'})
 -- Bucket count is calculated properly.
 --
 -- Cleanup after the previous tests.
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, false)
+---
+...
 _ = test_run:switch('storage_1_a')
 ---
 ...
@@ -736,6 +766,10 @@ buckets = vshard.storage.buckets_info()
 for bid, _ in pairs(buckets) do vshard.storage.bucket_force_drop(bid) end
 ---
 ...
+vshard.storage.sync()
+---
+- true
+...
 _ = test_run:switch('storage_2_a')
 ---
 ...
@@ -743,6 +777,16 @@ buckets = vshard.storage.buckets_info()
 ---
 ...
 for bid, _ in pairs(buckets) do vshard.storage.bucket_force_drop(bid) end
+---
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1, REPLICASET_2}, true)
 ---
 ...
 _ = test_run:switch('storage_1_a')
@@ -860,9 +904,31 @@ assert(not ok and not err)
 ---
 - true
 ...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, false)
+---
+...
+_ = test_run:switch('storage_1_a')
+---
+...
 vshard.storage.bucket_force_drop(10)
 ---
 - true
+...
+vshard.storage.sync()
+---
+- true
+...
+_ = test_run:switch('default')
+---
+...
+util.map_bucket_protection(test_run, {REPLICASET_1}, true)
+---
+...
+_ = test_run:switch('storage_1_a')
+---
 ...
 test_run:wait_cond(function() return ok or err end)
 ---

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -360,6 +360,27 @@ local function bucket_commit_delete(bucket)
     M.bucket_refs[bucket.id] = nil
 end
 
+local bucket_state_edges = {
+    -- From nothing. Have to cast nil to box.NULL explicitly then.
+    [box.NULL] = {BSTATE.RECEIVING},
+    [BSTATE.ACTIVE] = {BSTATE.PINNED, BSTATE.SENDING},
+    [BSTATE.PINNED] = {BSTATE.ACTIVE},
+    [BSTATE.SENDING] = {BSTATE.ACTIVE, BSTATE.SENT},
+    [BSTATE.SENT] = {BSTATE.GARBAGE},
+    [BSTATE.RECEIVING] = {BSTATE.GARBAGE, BSTATE.ACTIVE},
+    [BSTATE.GARBAGE] = {box.NULL},
+}
+
+-- Turn the edges into a table where edges[src][dst] would be true if the
+-- src->dst transition is allowed.
+for src, dsts in pairs(bucket_state_edges) do
+    local dst_dict = {}
+    for _, dst in pairs(dsts) do
+        dst_dict[dst] = true
+    end
+    bucket_state_edges[src] = dst_dict
+end
+
 --
 -- Validate whether _bucket update is possible. Bad ones need to be rejected for
 -- the sake of keeping data consistency. Ideally it should never throw. But
@@ -368,36 +389,50 @@ end
 --
 local function bucket_prepare_update(old_bucket, new_bucket)
     local new_status = new_bucket.status
+    local old_status = old_bucket ~= nil and old_bucket.status or box.NULL
     local bid = new_bucket.id
     local ref = M.bucket_refs[bid]
+    -- Check if existing refs allow the bucket to transfer to a new status.
     if old_bucket == nil and ref ~= nil then
         bucket_reject_update(bid, "new bucket can't have a ref object")
-    end
-    if new_status == BSTATE.PINNED or new_status == BSTATE.ACTIVE then
-        return
     end
     if new_status == BSTATE.SENDING or new_status == BSTATE.SENT then
         if ref ~= nil and ref.rw > 0 then
             bucket_reject_update(bid, "'%s' bucket can't have rw refs",
                                  new_status)
         end
-        return
-    end
-    if new_status == BSTATE.GARBAGE or new_status == BSTATE.RECEIVING then
+    elseif new_status == BSTATE.GARBAGE or new_status == BSTATE.RECEIVING then
         if ref ~= nil and (ref.rw > 0 or ref.ro > 0) then
             bucket_reject_update(bid, "'%s' bucket can't have any refs",
                                  new_status)
         end
+    end
+    if new_status == old_status then
         return
     end
-    bucket_reject_update(bid, "unknown bucket status: '%s'", new_status)
+    local src = bucket_state_edges[old_status]
+    if not src or not bucket_state_edges[new_status] then
+        bucket_reject_update(bid, "unknown bucket status '%s'",
+                             not src and old_status or new_status)
+    elseif not src[new_status] then
+        bucket_reject_update(bid, "transition '%s' to '%s' is not allowed",
+                             old_status == box.NULL and 'nil' or old_status,
+                             new_status == box.NULL and 'nil' or new_status)
+    end
 end
 
 local function bucket_prepare_delete(bucket)
     local bid = bucket.id
+    local status = bucket.status
     local ref = M.bucket_refs[bid]
     if ref ~= nil and (ref.ro > 0 or ref.rw > 0) then
         bucket_reject_update(bid, "can't delete a bucket with refs")
+    end
+    local src = bucket_state_edges[status]
+    if not src then
+        bucket_reject_update(bid, "unknown bucket status '%s'", status)
+    elseif not src[box.NULL] then
+        bucket_reject_update(bid, "can't delete '%s' bucket", status)
     end
 end
 
@@ -1486,7 +1521,14 @@ local function bucket_force_create_impl(first_bucket_id, count)
     box.begin()
     local limit = consts.BUCKET_CHUNK_SIZE
     for i = first_bucket_id, first_bucket_id + count - 1 do
-        _bucket:insert({i, consts.BUCKET.ACTIVE})
+        -- Buckets are protected with on_replace trigger, which
+        -- prohibits the creation of the ACTIVE buckets from nowhere,
+        -- as this is done only for bootstrap and not during the normal
+        -- work of vshard. So, as we don't want to disable the protection
+        -- of the buckets for the whole replicaset for bootstrap, a bucket's
+        -- status must go the following way: none -> RECEIVING -> ACTIVE.
+        _bucket:insert({i, consts.BUCKET.RECEIVING})
+        _bucket:replace({i, consts.BUCKET.ACTIVE})
         limit = limit - 1
         if limit == 0 then
             box.commit()
@@ -3655,6 +3697,7 @@ M.schema_upgrade_master = schema_upgrade_master
 M.schema_upgrade_handlers = schema_upgrade_handlers
 M.schema_version_make = schema_version_make
 M.schema_bootstrap = schema_init_0_1_15_0
+M.bucket_state_edges = bucket_state_edges
 
 M.bucket_are_all_rw = bucket_are_all_rw_public
 M.bucket_generation_wait = bucket_generation_wait


### PR DESCRIPTION
After https://github.com/tarantool/vshard/issues/173 buckets will be protected from GC if replicas have refs,
and they can't change to a bad status if there are running requests.
For example, a bucket can't be deleted if it has any refs.

However it seems like a couple of replicas might get same tuple in
_bucket in different states:

- Node1 is a master, node2 is a replica, bucket1 is ACTIVE on both;
- Node1 sends bucket1 to another replicaset;
- The bucket becomes SENT on both nodes;
- Node1 and node2 loose replication. But netbox still works;
- Node1 and node2 drop each other from config and from replication;
- Each of them becomes master and deletes the SENT bucket;
- Node2 receives the bucket from another replicaset again. Now it is
  ACTIVE here and not present on node1 at all. It wasn't accessed on
  the node2, so a ref doesn't exists;
- On the other replicaset the bucket becomes SENT and then it is deleted;
- Node1 and node2 again get their old config and restore the replication;
- Node2 receives removal of the bucket from node1;
- Node1 receives data for the deleted bucket from node2, which was
  re-received from another replicaset;

This is of course a result of multiple sequential bad reconfiguration
steps. But this particular case could be detected.

As a follow up to https://github.com/tarantool/vshard/issues/173 it might be feasible to validate bucket state
transitions in _bucket:on_replace() trigger. This transition must be
one of these:

    * none -> RECEIVING
    * RECEIVING -> GARBAGE
    * RECEIVING -> ACTIVE
    * PINNED <-> ACTIVE <-> SENDING -> SENT -> GARBAGE -> none

Buckets now are protected with on_replace trigger, which also prohibits
the creation of the ACTIVE buckets from nowhere, as this is done only for
bootstrap and not during the normal work of vshard. We should either allow
transition from none to ACTIVE or create them like that:
none -> RECEIVING-> ACTIVE. We cannot disable protection and create ACTIVE
buckets as we don't know how much bootstrap will take on the other
instances, where protection must be disabled too.

Going through the RECEIVING status during bootstrap seems to be more
preferable way of solving the problem, rather then allowing creating ACTIVE
buckets. We should reduce the chance of creating unwanted buckets as
e.g. if at least one extra bucket is be created in cluster, rebalancing
process stops.

Closes https://github.com/tarantool/vshard/issues/377

NO_DOC=internal change