### PR TITLE
test: fix flaky storage/storage.test.lua

### DIFF
--- a/test/storage/storage.result
+++ b/test/storage/storage.result
@@ -955,8 +955,7 @@ vshard.storage._call('info')
 _ = test_run:cmd('stop server storage_1_a')
 ---
 ...
-_ = test_run:cmd('start server storage_1_a with wait=False, '..                 \
-                 'args="boot_before_cfg"')
+_ = test_run:cmd('start server storage_1_a with args="boot_before_cfg"')
 ---
 ...
 _ = test_run:switch('storage_1_a')

--- a/test/storage/storage.test.lua
+++ b/test/storage/storage.test.lua
@@ -303,8 +303,7 @@ vshard.storage._call('info')
 -- gh-123, gh-298: storage auto-enable/disable depending on instance state.
 --
 _ = test_run:cmd('stop server storage_1_a')
-_ = test_run:cmd('start server storage_1_a with wait=False, '..                 \
-                 'args="boot_before_cfg"')
+_ = test_run:cmd('start server storage_1_a with args="boot_before_cfg"')
 _ = test_run:switch('storage_1_a')
 -- Leaving box.cfg() not called won't work because at 1.10 test-run somewhy
 -- raises an error when try to start an instance without box.cfg(). It can only


### PR DESCRIPTION
Sometimes it was failing (both with and without output) with an error in .reject file that `vshard` variable wasn't defined after storage_1_a restart.

The reason was that the restart was done with `wait=False` param. But there is no reason for it. Maybe there was before, but now the waiting is certainly fine.

Without the waiting it could happen that box.cfg is called and listen is done, but box.cfg didn't end yet and
`vshard = require('vshard')` apparently isn't done.

Closes #378

NO_DOC=bugfix