### PR TITLE
test: fix flaky storage/storage_2_test.lua

### DIFF
--- a/test/storage-luatest/storage_2_test.lua
+++ b/test/storage-luatest/storage_2_test.lua
@@ -170,7 +170,7 @@ local function test_storage_callro_refrw_loss(g, user_err)
     -- drop.
     rep_a:exec(bucket_set_protection, {false})
     rep_b:exec(bucket_force_drop, {bid})
-    rep_a:wait_vclock_of(rep_a)
+    rep_a:wait_vclock_of(rep_b)
     rep_a:exec(bucket_set_protection, {true})
     rep_a:exec(bucket_check_no_ref, {bid})
 


### PR DESCRIPTION
Sometimes the ref wasn't deleted as the replica_a wasn't
properly synchronized with the master due to misprint in
wait_vclock_of.

Closes #375

NO_DOC=bugfix