### PR TITLE
Pick a replica according prefered zone (highest priority replica zone) in round-robin manner.

### DIFF
--- a/vshard/router/init.lua
+++ b/vshard/router/init.lua
@@ -576,11 +576,15 @@ local function router_call_impl(router, bucket_id, mode, prefer_replica,
     local call
     if mode == 'read' then
         if prefer_replica then
-            if balance then
+            if balance == 2 then
+                call = 'callbzre'
+            elseif balance then
                 call = 'callbre'
             else
                 call = 'callre'
             end
+        elseif balance == 2 then
+            call = 'callbzro'
         elseif balance then
             call = 'callbro'
         else
@@ -698,6 +702,10 @@ local function router_callbro(router, bucket_id, ...)
     return router_call_impl(router, bucket_id, 'read', false, true, ...)
 end
 
+local function router_callbzro(router, bucket_id, ...)
+    return router_call_impl(router, bucket_id, 'read', false, 2, ...)
+end
+
 local function router_callrw(router, bucket_id, ...)
     return router_call_impl(router, bucket_id, 'write', false, false, ...)
 end
@@ -708,6 +716,10 @@ end
 
 local function router_callbre(router, bucket_id, ...)
     return router_call_impl(router, bucket_id, 'read', true, true, ...)
+end
+
+local function router_callbzre(router, bucket_id, ...)
+    return router_call_impl(router, bucket_id, 'read', true, 2, ...)
 end
 
 local function router_call(router, bucket_id, opts, ...)
@@ -1660,6 +1672,8 @@ local router_mt = {
         call = router_make_api(router_call),
         callro = router_make_api(router_callro),
         callbro = router_make_api(router_callbro),
+        callbzro = router_make_api(router_callbzro),
+        callbzre = router_make_api(router_callbzre),
         callrw = router_make_api(router_callrw),
         callre = router_make_api(router_callre),
         callbre = router_make_api(router_callbre),


### PR DESCRIPTION
Pick a replica according prefered zone (highest priority replica zone) in round-robin manner.

Current `callr*` calls use only first replica. Current `callbr*` calls use replicas in round-robin manner only, without zonal preferences that leads to extra cross zonal traffic (that costs some penies).

Current PR suggests two new methods and new load-balancing (replica selection) algorithm:
* callbzro - prefer, but not limit, Inner zone balanced method with round-robin. Similar to existing `callbro`;
* callbzre - prefer, but not limit, Inner zone balanced method with round-robin. Similar to existing `callbre`;
