### PR TITLE
test: fix flaky router/map_reduce

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -63,6 +63,7 @@ local util = require('vshard.util')
 local fiber_clock = fiber.clock
 local fiber_yield = fiber.yield
 local fiber_cond_wait = util.fiber_cond_wait
+local future_wait = util.future_wait
 local gsc = util.generate_self_checker
 
 --
@@ -717,7 +718,7 @@ local function replicaset_map_call(replicaset, func, args, opts)
     --
     map = table.new(0, replica_count)
     for uuid, future in pairs(futures) do
-        res, err = future:wait_result(timeout)
+        res, err = future_wait(future, timeout)
         if res == nil then
             err_uuid = uuid
             goto fail
@@ -926,7 +927,7 @@ local function replicaset_locate_master(replicaset)
             -- a sign of a master.
             timeout = 0
         end
-        res, err = f:wait_result(timeout)
+        res, err = future_wait(f, timeout)
         timeout = deadline - fiber_clock()
         if not res then
             f:discard()


### PR DESCRIPTION
Currently map_reduce (or any other test related to the functions, in
which loop over futures is used) can fail with the usage exception
due to the fact, that negative values are not allowed in wait_result.

This commit introduces new util function, which is supposed to be used
instead of wait_result. It throws box.error.TIMEOUT in case of a
negative value as argument.

Note, that errors are inconsistent: the function may return either
TimedOut error (which is one, returned from the original wait_result)
or box.error.TIMEOUT.

Closes https://github.com/tarantool/vshard/issues/384

NO_DOC=bugfix