### PR TITLE
ci: fix ubuntu version

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -27,11 +27,11 @@ jobs:
     env:
       TNT_RELEASE_PATH: /home/runner/tnt-release
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
         if: startsWith(matrix.tarantool, 'release') != true
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool }}
 


### PR DESCRIPTION
Currently when running CI on 2.7 and 2.8 versions of tarantool
the 2.6.0-0-g47aa4e01e is being installed instead.

Fetching versions with setup-tarantool doesn't work properly with
ubuntu-22.04, so, let's use 20.04, as it's done in all other repos.
Let's also update setup-tarantool version while we're here.

Co-authored-by: Yaroslav Lobankov <y.lobankov@tarantool.org>

NO_TEST=ci
NO_DOC=ci