### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -6,6 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'vshard'
+
   linux:
     # We want to run on external PRs, but not on our own internal
     # PRs as they'll be run by the push to the branch.

--- a/vshard/consts.lua
+++ b/vshard/consts.lua
@@ -1,4 +1,8 @@
 return {
+    -- Сontains the module version.
+    -- Requires manual update in case of release commit.
+    VERSION = '0.1.22',
+
     -- Bucket FSM
     BUCKET = {
         ACTIVE = 'active',

--- a/vshard/init.lua
+++ b/vshard/init.lua
@@ -1,6 +1,9 @@
+local consts = require('vshard.consts')
+
 return {
+    _VERSION = consts.VERSION,
     router = require('vshard.router'),
     storage = require('vshard.storage'),
-    consts = require('vshard.consts'),
+    consts = consts,
     error = require('vshard.error'),
 }


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204