### PR TITLE
storage: fix _truncate blocking all deletions

### DIFF
--- a/test/storage-luatest/storage_1_test.lua
+++ b/test/storage-luatest/storage_1_test.lua
@@ -123,3 +123,19 @@ test_group.test_simultaneous_cfg = function(g)
     err = storage_cfg()
     t.assert_equals(err, nil)
 end
+
+--
+-- gh-400: _truncate deletions should be let through.
+--
+test_group.test_truncate_space_clear = function(g)
+    g.replica_1_a:exec(function()
+       local s = box.schema.create_space('test')
+       s:create_index('pk')
+       s:replace{1}
+       s:truncate()
+       local sid = s.id
+       ilt.assert(box.space._truncate:get{sid} ~= nil)
+       s:drop()
+       ilt.assert(box.space._truncate:get{sid} == nil)
+    end)
+end

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -525,7 +525,7 @@ end
 -- attach to _truncate space.
 --
 local function bucket_on_truncate_f(_, new_tuple)
-    if new_tuple[1] ~= box.space._bucket.id then
+    if new_tuple == nil or new_tuple[1] ~= box.space._bucket.id then
         return
     end
     -- There is no a valid truncation of _bucket. Because it would require to


### PR DESCRIPTION
There is an on_replace trigger in _truncate space protecting from _bucket space clearance. The trigger wasn't ready to _truncate having deletions. It happens when any previously truncated space gets deleted.

As a result, _truncate didn't allow any deletions and its tuples were just staying permanently.

The patch makes the storage ignore _truncate deletions. They don't affect bucket rows anyway.

Fixes #400

NO_DOC=bugfix