### PR TITLE
Support Tarantool 3.0

### DIFF
--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -190,7 +190,13 @@ function Server:replicaset_uuid()
     if self.replicaset_uuid_value then
         return self.replicaset_uuid_value
     end
-    local uuid = self:exec(function() return box.info.cluster.uuid end)
+    local uuid = self:exec(function()
+        local info = box.info
+        if info.replicaset then
+            return info.replicaset.uuid
+        end
+        return info.cluster.uuid
+    end)
     if uuid == nil then
         -- Probably didn't bootstrap yet. Listen starts before replicaset UUID
         -- is assigned.

--- a/test/storage-luatest/storage_1_1_test.lua
+++ b/test/storage-luatest/storage_1_1_test.lua
@@ -226,9 +226,7 @@ test_group.test_on_bucket_event = function(g)
         end)
     end, {g.params.engine})
 
-    local rs1_uuid = g.replica_1_a:exec(function()
-        return box.info.cluster.uuid
-    end)
+    local rs1_uuid = g.replica_1_a:replicaset_uuid()
     local bid = g.replica_2_a:exec(function(rs1_uuid)
         local bid = _G.get_first_bucket()
         box.space.data1:insert({10, bid})
@@ -285,7 +283,7 @@ test_group.test_basic_storage_service_info = function(g)
         -- Break timeout in order to get error
         rawset(_G, 'chunk_timeout', ivconst.REBALANCER_CHUNK_TIMEOUT)
         ivconst.REBALANCER_CHUNK_TIMEOUT = 1e-6
-        return box.info.cluster.uuid
+        return ivutil.replicaset_uuid()
     end)
 
     g.replica_2_a:exec(function(uuid)

--- a/test/storage/storage_1_1.lua
+++ b/test/storage/storage_1_1.lua
@@ -11,19 +11,19 @@ util = require('util')
 instance_uuid = nil
 replicaset_uuid = nil
 if name == 'storage_1_1' then
-	box.cfg{}
-	instance_uuid = box.info.uuid
-	replicaset_uuid = box.info.cluster.uuid
+    box.cfg{}
+    instance_uuid = box.info.uuid
+    replicaset_uuid = box.info.cluster.uuid
 elseif name == 'storage_1_2' then
-	box.cfg{instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
-	instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce000000'
-	replicaset_uuid = box.info.cluster.uuid
+    box.cfg{instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
+    instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce000000'
+    replicaset_uuid = box.info.cluster.uuid
 elseif name == 'storage_1_3' then
-	box.cfg{replicaset_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
-	instance_uuid = box.info.uuid
-	replicaset_uuid = '8a274925-a26d-47fc-9e1b-af88ce000000'
+    box.cfg{replicaset_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
+    instance_uuid = box.info.uuid
+    replicaset_uuid = '8a274925-a26d-47fc-9e1b-af88ce000000'
 else
-	assert(false)
+    assert(false)
 end
 
 cfg = {

--- a/test/storage/storage_1_1.lua
+++ b/test/storage/storage_1_1.lua
@@ -8,16 +8,18 @@ if os.getenv('ADMIN') then
     require('console').listen(os.getenv('ADMIN'))
 end
 util = require('util')
+vutil = require('vshard.util')
+
 instance_uuid = nil
 replicaset_uuid = nil
 if name == 'storage_1_1' then
     box.cfg{}
     instance_uuid = box.info.uuid
-    replicaset_uuid = box.info.cluster.uuid
+    replicaset_uuid = vutil.replicaset_uuid()
 elseif name == 'storage_1_2' then
     box.cfg{instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
     instance_uuid = '8a274925-a26d-47fc-9e1b-af88ce000000'
-    replicaset_uuid = box.info.cluster.uuid
+    replicaset_uuid = vutil.replicaset_uuid()
 elseif name == 'storage_1_3' then
     box.cfg{replicaset_uuid = '8a274925-a26d-47fc-9e1b-af88ce939412'}
     instance_uuid = box.info.uuid

--- a/test/unit-luatest/util_test.lua
+++ b/test/unit-luatest/util_test.lua
@@ -262,3 +262,12 @@ test_group.test_future_wait_timeout = function(g)
     -- Everything is all right, wait for result
     t.assert_equals(vutil.future_wait(f)[1], true)
 end
+
+test_group.test_replicaset_uuid = function(g)
+    g.server:exec(function()
+        local _schema = box.space._schema
+        local t = _schema:get{'replicaset_uuid'}
+        t = t ~= nil and t or _schema:get{'cluster'}
+        ilt.assert_equals(ivutil.replicaset_uuid(), t[2])
+    end)
+end

--- a/test/upgrade/upgrade.result
+++ b/test/upgrade/upgrade.result
@@ -8,13 +8,28 @@ git_util = require('git_util')
 util = require('util')
  | ---
  | ...
-
--- Commit "Improve compatibility with 1.9".
-version_0_1_15_0 = '79a4dbfc4229e922cbfe4be259193a7b18dc089d'
+vutil = require('vshard.util')
  | ---
  | ...
-vshard_copy_path = util.git_checkout('vshard_git_tree_copy_0_1_15_0',           \
-                                     version_0_1_15_0)
+
+oldest_version = nil
+ | ---
+ | ...
+is_at_least_3_0 = vutil.version_is_at_least(3, 0, 0, 'entrypoint', 0, 0)
+ | ---
+ | ...
+-- On 3.0 old vshard versions won't work. The users are supposed to update
+-- vshard first, and then update Tarantool.
+if is_at_least_3_0 then                                                         \
+-- Commit 'Support 3.0'.                                                        \
+    oldest_version = '0243bc692fb6b34e26e89ea032214859f1ad53ea'                 \
+else                                                                            \
+-- Commit 'Improve compatibility with 1.9'.                                     \
+    oldest_version = '79a4dbfc4229e922cbfe4be259193a7b18dc089d'                 \
+end
+ | ---
+ | ...
+vshard_copy_path = util.git_checkout('vshard_git_tree_copy', oldest_version)
  | ---
  | ...
 
@@ -39,7 +54,10 @@ util.wait_master(test_run, REPLICASET_1, 'storage_1_a')
 util.wait_master(test_run, REPLICASET_2, 'storage_2_a')
  | ---
  | ...
-util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, 'bootstrap_storage(\'memtx\')')
+util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, [[                       \
+    bootstrap_storage('memtx')                                                  \
+    is_at_least_3_0 = %s                                                        \
+]], is_at_least_3_0)
  | ---
  | ...
 
@@ -47,18 +65,19 @@ test_run:switch('storage_1_a')
  | ---
  | - true
  | ...
-box.space._schema:get({'oncevshard:storage:1'}) or box.space._schema:select()
+if is_at_least_3_0 then                                                         \
+    local t = box.space._schema:get{'vshard_version'}                           \
+    assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
+    assert(vshard.storage.internal.schema_current_version ~= nil)               \
+    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
+else                                                                            \
+    assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
+    assert(vshard.storage.internal.schema_current_version == nil)               \
+    assert(vshard.storage.internal.schema_latest_version == nil)                \
+end
  | ---
- | - ['oncevshard:storage:1']
  | ...
-vshard.storage.internal.schema_current_version
- | ---
- | - null
- | ...
-vshard.storage.internal.schema_latest_version
- | ---
- | - null
- | ...
+
 bucket_count = vshard.consts.DEFAULT_BUCKET_COUNT / 2
  | ---
  | ...
@@ -80,21 +99,17 @@ test_run:switch('storage_2_a')
  | ---
  | - true
  | ...
-box.space._schema:get({'oncevshard:storage:1'}) or box.space._schema:select()
+if is_at_least_3_0 then                                                         \
+    local t = box.space._schema:get{'vshard_version'}                           \
+    assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
+    assert(vshard.storage.internal.schema_current_version ~= nil)               \
+    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
+else                                                                            \
+    assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
+    assert(vshard.storage.internal.schema_current_version == nil)               \
+    assert(vshard.storage.internal.schema_latest_version == nil)                \
+end
  | ---
- | - ['oncevshard:storage:1']
- | ...
-vshard.storage.internal.schema_current_version
- | ---
- | - null
- | ...
-vshard.storage.internal.schema_latest_version
- | ---
- | - null
- | ...
-vshard.storage._call == nil
- | ---
- | - true
  | ...
 bucket_count = vshard.consts.DEFAULT_BUCKET_COUNT / 2
  | ---

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -2023,7 +2023,7 @@ end
 -- Send a bucket to other replicaset.
 --
 local function bucket_send_xc(bucket_id, destination, opts, exception_guard)
-    local uuid = box.info.cluster.uuid
+    local uuid = util.replicaset_uuid()
     local status, ok
     local ref, err = bucket_refrw_touch(bucket_id)
     if not ref then
@@ -3400,10 +3400,11 @@ local function storage_cfg(cfg, this_replica_uuid, is_reload)
                                     '"%s" but "%s" in arguments', info.uuid,
                                     this_replica_uuid))
             end
-            if this_replicaset.uuid ~= info.cluster.uuid then
+            local real_rs_uuid = util.replicaset_uuid(info)
+            if this_replicaset.uuid ~= real_rs_uuid then
                 error(string.format('Replicaset UUID mismatch: already set ' ..
                                     '"%s" but "%s" in vshard config',
-                                    info.cluster.uuid, this_replicaset.uuid))
+                                    real_rs_uuid, this_replicaset.uuid))
             end
         end
         local ok, err = pcall(box.cfg, box_cfg)


### PR DESCRIPTION
It is not released yet and not even pushed to master branch. But vshard has to be ready in advance to make the integration tests pass. For trying 3.0 yourself use https://github.com/tarantool/tarantool/pull/8289.