### PR TITLE
storage: partly fix doubled buckets

### DIFF
--- a/test/luatest_helpers/vtest.lua
+++ b/test/luatest_helpers/vtest.lua
@@ -71,8 +71,8 @@ end
 -- helps not to care.
 --
 local function error_is_timeout(err)
-    return err.type == 'ClientError' and err.code == box.error.TIMEOUT or
-           err.type == 'TimedOut'
+    return err.code == box.error.TIMEOUT or (err.code == box.error.PROC_LUA and
+           err.message == 'Timeout exceeded') or err.type == 'TimedOut'
 end
 
 --

--- a/test/rebalancer/bucket_ref.result
+++ b/test/rebalancer/bucket_ref.result
@@ -124,23 +124,23 @@ vshard.storage.buckets_info(1)
     ref_ro: 1
     id: 1
 ...
-_ = test_run:switch('box_2_a')
----
-...
-vshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = true
----
-...
 _ = test_run:switch('box_1_a')
 ---
 ...
-res, err = vshard.storage.bucket_send(1, util.replicasets[2])
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = true
 ---
 ...
-res, util.portable_error(err)
+f2 = fiber.create(function()                                                    \
+    vshard.storage.bucket_send(1, util.replicasets[2])                          \
+end)
 ---
-- null
-- type: ClientError
-  message: Timeout exceeded
+...
+test_run:wait_cond(function()                                                   \
+    local i = vshard.storage.buckets_info(1)[1]                                 \
+    return i.status == vshard.consts.BUCKET.SENDING                             \
+end)
+---
+- true
 ...
 vshard.storage.buckets_info(1)
 ---
@@ -187,20 +187,19 @@ vshard.storage.buckets_info(1)
     destination: <replicaset_2>
     id: 1
 ...
-_ = test_run:cmd("setopt delimiter ';'")
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = false
 ---
 ...
-while true do
-	local i = vshard.storage.buckets_info(1)[1]
-    if i.status == vshard.consts.BUCKET.SENT and i.ro_lock then
-        break
-    end
-    fiber.sleep(0.01)
-end;
+test_run:wait_cond(function() return f2:status() == 'dead' end)
 ---
+- true
 ...
-_ = test_run:cmd("setopt delimiter ''");
+test_run:wait_cond(function()                                                   \
+    local i = vshard.storage.buckets_info(1)[1]                                 \
+    return i.status == vshard.consts.BUCKET.SENT and i.ro_lock                  \
+end)
 ---
+- true
 ...
 vshard.storage.buckets_info(1)
 ---
@@ -237,9 +236,6 @@ vshard.storage.buckets_info(1)
 - 1:
     status: active
     id: 1
-...
-vshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = false
----
 ...
 --
 -- Test that when bucket_send waits for rw == 0, it is waked up

--- a/test/rebalancer/receiving_bucket.result
+++ b/test/rebalancer/receiving_bucket.result
@@ -110,9 +110,11 @@ vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 10})
 ---
 - true
 ...
+wait_bucket_is_collected(1)
+---
+...
 box.space._bucket:get{1}
 ---
-- [1, 'sent', '<replicaset_2>']
 ...
 _ = test_run:switch('box_2_a')
 ---
@@ -223,31 +225,21 @@ util.is_timeout_error(err)
 ---
 - true
 ...
-box.space._bucket:get{101}
+wait_bucket_is_collected(101)
 ---
-- [101, 'sending', '<replicaset_1>']
-...
-while box.space._bucket:get{101}.status ~= vshard.consts.BUCKET.ACTIVE do vshard.storage.recovery_wakeup() fiber.sleep(0.01) end
----
-...
-box.space._bucket:get{101}
----
-- [101, 'active']
 ...
 _ = test_run:switch('box_1_a')
----
-...
-while _bucket:get{101} do fiber.sleep(0.01) end
 ---
 ...
 vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
 ---
 ...
-fiber.sleep(0.1)
+test_run:wait_cond(function()                                                   \
+    vshard.storage.recovery_wakeup()                                            \
+    return box.space._bucket:get{101}.status == vshard.consts.BUCKET.ACTIVE     \
+end)
 ---
-...
-box.space._bucket:get{101}
----
+- true
 ...
 --
 -- gh-122 and gh-73: a bucket can be transferred not completely,

--- a/test/storage-luatest/storage_1_1_1_test.lua
+++ b/test/storage-luatest/storage_1_1_1_test.lua
@@ -1,0 +1,102 @@
+local t = require('luatest')
+local vtest = require('test.luatest_helpers.vtest')
+local vutil = require('vshard.util')
+
+local group_config = {{engine = 'memtx'}, {engine = 'vinyl'}}
+
+if vutil.feature.memtx_mvcc then
+    table.insert(group_config, {
+        engine = 'memtx', memtx_use_mvcc_engine = true
+    })
+    table.insert(group_config, {
+        engine = 'vinyl', memtx_use_mvcc_engine = true
+    })
+end
+
+local test_group = t.group('storage', group_config)
+
+local cfg_template = {
+    sharding = {
+        {
+            replicas = {
+                replica_1_a = {
+                    master = true,
+                },
+            },
+        },
+        {
+            replicas = {
+                replica_2_a = {
+                    master = true,
+                },
+            },
+        },
+        {
+            replicas = {
+                replica_3_a = {
+                    master = true,
+                },
+            },
+        },
+    },
+    bucket_count = 15
+}
+local global_cfg
+
+test_group.before_all(function(g)
+    cfg_template.memtx_use_mvcc_engine = g.params.memtx_use_mvcc_engine
+    global_cfg = vtest.config_new(cfg_template)
+
+    vtest.cluster_new(g, global_cfg)
+    vtest.cluster_bootstrap(g, global_cfg)
+    vtest.cluster_rebalancer_disable(g)
+end)
+
+test_group.after_all(function(g)
+    g.cluster:drop()
+end)
+
+--
+-- Test that manual vshard.storage.bucket_send() cannot lead to
+-- doubled buckets (gh-414).
+--
+test_group.test_manual_bucket_send_doubled_buckets = function(g)
+    vtest.cluster_exec_each_master(g, function()
+        _G.bucket_recovery_pause()
+    end)
+
+    local uuid_2 = g.replica_2_a:exec(function()
+        ivshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = true
+        return ivutil.replicaset_uuid()
+    end)
+
+    local bid = g.replica_1_a:exec(function(uuid)
+        local bid = _G.get_first_bucket()
+        local ok, err = ivshard.storage.bucket_send(bid, uuid)
+        ilt.assert(ivtest.error_is_timeout(err))
+        ilt.assert_not(ok, 'bucket_send not ok')
+        return bid
+    end, {uuid_2})
+
+    g.replica_2_a:exec(function(bid, uuid)
+        ivshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = false
+        ilt.assert_equals(box.space._bucket:get(bid).status,
+                          ivconst.BUCKET.ACTIVE)
+        local ok, err = ivshard.storage.bucket_send(bid, uuid)
+        ilt.assert_equals(err, nil, 'bucket_send no error')
+        ilt.assert(ok, 'bucket_send ok')
+        _G.bucket_recovery_continue()
+    end, {bid, g.replica_3_a:replicaset_uuid()})
+
+    g.replica_3_a:exec(function(bid)
+        ilt.assert_equals(box.space._bucket:get(bid).status,
+                          ivconst.BUCKET.ACTIVE)
+    end, {bid})
+
+    g.replica_1_a:exec(function(bid)
+        _G.bucket_recovery_continue()
+        _G.bucket_recovery_wait()
+        _G.bucket_gc_wait()
+        ilt.assert_equals(box.space._bucket:get(bid), nil)
+    end, {bid})
+end

--- a/test/storage/recovery_errinj.result
+++ b/test/storage/recovery_errinj.result
@@ -83,9 +83,11 @@ ret, util.is_timeout_error(err)
 _bucket = box.space._bucket
 ---
 ...
+wait_bucket_is_collected(1)
+---
+...
 _bucket:get{1}
 ---
-- [1, 'sending', '<replicaset_2>']
 ...
 _ = test_run:switch('storage_2_a')
 ---

--- a/test/storage/recovery_errinj.test.lua
+++ b/test/storage/recovery_errinj.test.lua
@@ -34,6 +34,7 @@ _ = test_run:switch('storage_1_a')
 ret, err = vshard.storage.bucket_send(1, util.replicasets[2], {timeout = 0.1})
 ret, util.is_timeout_error(err)
 _bucket = box.space._bucket
+wait_bucket_is_collected(1)
 _bucket:get{1}
 
 _ = test_run:switch('storage_2_a')

--- a/test/storage/ref.result
+++ b/test/storage/ref.result
@@ -164,14 +164,14 @@ wait_bucket_is_collected(1)
 --
 -- While bucket move is in progress, ref won't work.
 --
-vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
- | ---
- | ...
 
 _ = test_run:switch('storage_1_a')
  | ---
  | ...
 fiber = require('fiber')
+ | ---
+ | ...
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = true
  | ---
  | ...
 _ = fiber.create(vshard.storage.bucket_send, 1, util.replicasets[2],            \
@@ -195,14 +195,10 @@ end)
  | ---
  | ...
 
-_ = test_run:switch('storage_2_a')
- | ---
- | ...
-vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
- | ---
- | ...
-
 _ = test_run:switch('storage_1_a')
+ | ---
+ | ...
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = false
  | ---
  | ...
 wait_bucket_is_collected(1)

--- a/test/storage/ref.test.lua
+++ b/test/storage/ref.test.lua
@@ -71,10 +71,10 @@ wait_bucket_is_collected(1)
 --
 -- While bucket move is in progress, ref won't work.
 --
-vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 
 _ = test_run:switch('storage_1_a')
 fiber = require('fiber')
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = true
 _ = fiber.create(vshard.storage.bucket_send, 1, util.replicasets[2],            \
                  {timeout = big_timeout})
 ok, err = lref.add(rid, sid, small_timeout)
@@ -85,10 +85,8 @@ _ = fiber.create(function()                                                     
     ok, err = lref.add(rid, sid, big_timeout)                                   \
 end)
 
-_ = test_run:switch('storage_2_a')
-vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
-
 _ = test_run:switch('storage_1_a')
+vshard.storage.internal.errinj.ERRINJ_LAST_SEND_DELAY = false
 wait_bucket_is_collected(1)
 test_run:wait_cond(function() return ok or err end)
 lref.use(rid, sid)


### PR DESCRIPTION
Currently buckets with 'active' status can appear on several shards in case of manual use of vshard.storage.bucket_send() in the following situation: storage S1 has bucket B, which is sent to S2, but then connection broke. The bucket is in the state S1 {B: sending-to-s2}, S2 {B: active}. Now if the user will do vshard.storage.bucket_send(S2 -> S3), then we will get this: S1 {B: sending-to-s2}, S2: {}, S3: {B: active}. Now when recovery fiber will wakeup on S1, it will see that B is sending-to-s2 but S2 doesn't have the bucket. Recovery will then assume that S2 already deleted B, and will recover it on S1. Now we have S1 {B: active} and S3 {B: active}, doubled buckets situation.

Let's fix that by turning local bucket to SENT and only after that the remote bucket to ACTIVE. It's safe to do, as local bucket will be garbade collected and the remote one will be turned to ACTIVE by recovery process.

Closes #414

NO_DOC=bugfix