### PR TITLE
test: fix flaky rebalancer/rebalancer.test.lua

### DIFF
--- a/test/rebalancer/rebalancer.result
+++ b/test/rebalancer/rebalancer.result
@@ -149,9 +149,6 @@ test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
 ---
 ...
-vshard.storage.rebalancer_wakeup()
----
-...
 wait_rebalancer_state("Rebalance routes are sent", test_run)
 ---
 ...

--- a/test/rebalancer/rebalancer.test.lua
+++ b/test/rebalancer/rebalancer.test.lua
@@ -78,7 +78,6 @@ util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 
 test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
-vshard.storage.rebalancer_wakeup()
 wait_rebalancer_state("Rebalance routes are sent", test_run)
 
 wait_rebalancer_state('The cluster is balanced ok', test_run)


### PR DESCRIPTION
Currently the test hangs sometimes on the line, which waits for the message "Rebalance routes are sent" to appear in logs.

According to the logs this message appears, when hang happens, but it is located before the bunch of "aa..a", which means, that rebalancer managed to send routes before waiting actually started.

This happens due to the fact, that rebalancer is waked up before waiting. Let's not do that.

Closes #360

NO_DOC=testfix