### PR TITLE
test: fix flaky storage/storage.test.lua

### DIFF
--- a/test/storage/storage.result
+++ b/test/storage/storage.result
@@ -1018,10 +1018,20 @@ vshard.storage._call('info')
 --
 -- gh-123, gh-298: storage auto-enable/disable depending on instance state.
 --
+_ = test_run:switch('default')
+---
+...
 _ = test_run:cmd('stop server storage_1_a')
 ---
 ...
 _ = test_run:cmd('start server storage_1_a with args="boot_before_cfg"')
+---
+...
+-- We should wait for upstream on storage_1_b, as overwise we can get
+-- IPROTO_VOTE from it, which tries to access box.cfg.read_only for ballot
+-- generation. It won't be able to do that as at this point box.cfg will be
+-- a function, and tarantool will fail with panic.
+util.wait_master(test_run, REPLICASET_1, 'storage_1_a')
 ---
 ...
 _ = test_run:switch('storage_1_a')

--- a/test/storage/storage.test.lua
+++ b/test/storage/storage.test.lua
@@ -331,8 +331,14 @@ vshard.storage._call('info')
 --
 -- gh-123, gh-298: storage auto-enable/disable depending on instance state.
 --
+_ = test_run:switch('default')
 _ = test_run:cmd('stop server storage_1_a')
 _ = test_run:cmd('start server storage_1_a with args="boot_before_cfg"')
+-- We should wait for upstream on storage_1_b, as overwise we can get
+-- IPROTO_VOTE from it, which tries to access box.cfg.read_only for ballot
+-- generation. It won't be able to do that as at this point box.cfg will be
+-- a function, and tarantool will fail with panic.
+util.wait_master(test_run, REPLICASET_1, 'storage_1_a')
 _ = test_run:switch('storage_1_a')
 -- Leaving box.cfg() not called won't work because at 1.10 test-run somewhy
 -- raises an error when try to start an instance without box.cfg(). It can only


### PR DESCRIPTION
Currently the test sometimes fails with panic on cfg_get('read_only'). It's caused by emulating of unconfigured box, which is done by making box.cfg a function.

Here's what happens: we restart instance storage_1_a and emulate unconfigured box there. Instance storage_1_b didn't managed to connect for replication before this point, so it sends IPROTO_VOTE on applier connection. storage_1_a's box.cfg is a function, so getting 'read_only' option from it fails.

Let's fix that by using wait_master() function, which waits for all upstreams to have 'follow' mode. IPROTO_VOTE is sent (maybe not once) only during replicaset boostrap (after connection of the applier, but before IPROTO_SUBSCRIBE). Using wait_master() function will help us to be sure, that IPROTO_VOTE won't come while we emulate unconfigured box.

Closes #335

NO_DOC=testfix