### PR TITLE
test: fix flaky router/router.test.lua

### DIFF
--- a/test/router/router.result
+++ b/test/router/router.result
@@ -401,6 +401,14 @@ vshard.router.buckets_info(0, 3)
 _ = test_run:cmd('stop server storage_2_a')
 ---
 ...
+vshard.router.static.failover_fiber:wakeup()
+---
+...
+_ = test_run:wait_cond(function()                                               \
+    return test_run:grep_log('router_1', 'New replica storage_2_b') ~= nil      \
+end)
+---
+...
 util.check_error(vshard.router.call, 1, 'read', 'echo', {123})
 ---
 - null

--- a/test/router/router.test.lua
+++ b/test/router/router.test.lua
@@ -150,6 +150,10 @@ _ = vshard.router.bucket_discovery(2)
 _ = vshard.router.bucket_discovery(3)
 vshard.router.buckets_info(0, 3)
 _ = test_run:cmd('stop server storage_2_a')
+vshard.router.static.failover_fiber:wakeup()
+_ = test_run:wait_cond(function()                                               \
+    return test_run:grep_log('router_1', 'New replica storage_2_b') ~= nil      \
+end)
 util.check_error(vshard.router.call, 1, 'read', 'echo', {123})
 vshard.router.buckets_info(0, 3)
 _ = test_run:cmd('start server storage_2_a')


### PR DESCRIPTION
Currently the test may fail on retrieving info about buckets after
stopping the master. The router.call is made before we check statuses
of these buckets.

Deleting this call always results in `unreachable` state for buckets,
which means that if this call is done quickly we get test flakiness, as
failover sometimes doesn't have time to update nearest available replica
object.

Let's explicitly wake up failover and wait, until replica object is
updated.

Closes https://github.com/tarantool/vshard/issues/389

NO_DOC=testfix