### PR TITLE
test: use dofile() for configs instead of require

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ On storages call `vshard.storage.cfg(cfg, <INSTANCE_UUID>)`:
 local MY_UUID = "de0ea826-e71d-4a82-bbf3-b04a6413e417"
 
 -- Call a configuration provider
-local cfg = require('localcfg')
+local cfg = dofile('localcfg.lua')
 
 -- Start the database with sharding
 vshard = require('vshard')

--- a/example/router.lua
+++ b/example/router.lua
@@ -13,7 +13,7 @@ replicasets = {'cbf06940-0790-498b-948d-042b62cf3d29',
                'ac522f65-aa94-4134-9f64-51ee384f1a54'}
 
 -- Call a configuration provider
-cfg = require('localcfg')
+cfg = dofile('localcfg.lua')
 if arg[1] == 'discovery_disable' then
     cfg.discovery_mode = 'off'
 end

--- a/example/storage.lua
+++ b/example/storage.lua
@@ -14,7 +14,7 @@ if os.getenv('ADMIN') then
 end
 
 -- Call a configuration provider
-cfg = require('localcfg')
+cfg = dofile('localcfg.lua')
 -- Name to uuid map
 names = {
     ['storage_1_a'] = '8a274925-a26d-47fc-9e1b-af88ce939412',

--- a/test/failover/box_1_a.lua
+++ b/test/failover/box_1_a.lua
@@ -7,8 +7,8 @@ test_run = require('test_run').new()
 require('console').listen(os.getenv('ADMIN'))
 
 vshard = require('vshard')
-names = require('names')
-cfg = require('config')
+names = dofile('names.lua')
+cfg = dofile('config.lua')
 cfg.weights = nil
 vshard.storage.cfg(cfg, names.replica_uuid[NAME])
 

--- a/test/failover/config.lua
+++ b/test/failover/config.lua
@@ -1,4 +1,4 @@
-names = require('names')
+names = dofile('names.lua')
 replica = names.replica_uuid
 rs = names.rs_uuid
 weights = {

--- a/test/failover/router_1.lua
+++ b/test/failover/router_1.lua
@@ -5,11 +5,11 @@ test_run = require('test_run').new()
 
 local fio = require('fio')
 local name = fio.basename(arg[0], '.lua')
-cfg = require('config')
+cfg = dofile('config.lua')
 vshard = require('vshard')
 os = require('os')
 fiber = require('fiber')
-local names = require('names')
+local names = dofile('names.lua')
 log = require('log')
 rs_uuid = names.rs_uuid
 replica_uuid = names.replica_uuid

--- a/test/lua_libs/storage_template.lua
+++ b/test/lua_libs/storage_template.lua
@@ -7,7 +7,7 @@ fiber = require('fiber')
 test_run = require('test_run').new()
 util = require('util')
 require('console').listen(os.getenv('ADMIN'))
-cfg = rawget(_G, "cfg") or require('localcfg')
+cfg = rawget(_G, "cfg") or dofile('localcfg.lua')
 log = require('log')
 if not cfg.shard_index then
     cfg.shard_index = 'bucket_id'

--- a/test/misc/reconfigure.result
+++ b/test/misc/reconfigure.result
@@ -33,7 +33,7 @@ test_run:cmd('start server router_1')
 _ = test_run:switch('default')
 ---
 ...
-cfg = require('localcfg')
+cfg = dofile('localcfg.lua')
 ---
 ...
 cfg.sharding[util.replicasets[1]].replicas[util.name_to_uuid.storage_1_b] = nil

--- a/test/misc/reconfigure.test.lua
+++ b/test/misc/reconfigure.test.lua
@@ -11,7 +11,7 @@ test_run:cmd('create server router_1 with script="misc/router_1.lua", wait=True,
 test_run:cmd('start server router_1')
 
 _ = test_run:switch('default')
-cfg = require('localcfg')
+cfg = dofile('localcfg.lua')
 cfg.sharding[util.replicasets[1]].replicas[util.name_to_uuid.storage_1_b] = nil
 cfg.sharding[util.replicasets[2]].replicas[util.name_to_uuid.storage_2_a].master = nil
 cfg.sharding[util.replicasets[2]].replicas[util.name_to_uuid.storage_2_b].master = true

--- a/test/misc/storage_3_a.lua
+++ b/test/misc/storage_3_a.lua
@@ -5,7 +5,7 @@ local fio = require('fio')
 local NAME = fio.basename(arg[0], '.lua')
 
 -- Call a configuration provider
-cfg = require('localcfg')
+cfg = dofile('localcfg.lua')
 cfg.sharding['cbf06940-0790-498b-948d-042b62cf3d29'].replicas['3de2e3e1-9ebe-4d0d-abb1-26d301b84633'] = nil
 cfg.sharding['ac522f65-aa94-4134-9f64-51ee384f1a54'].replicas['1e02ae8a-afc0-4e91-ba34-843a356b8ed7'].master = nil
 cfg.sharding['ac522f65-aa94-4134-9f64-51ee384f1a54'].replicas['001688c3-66f8-4a31-8e19-036c17d489c2'].master = true

--- a/test/multiple_routers/router_1.lua
+++ b/test/multiple_routers/router_1.lua
@@ -8,7 +8,7 @@ local NAME = fio.basename(arg[0], '.lua')
 
 require('console').listen(os.getenv('ADMIN'))
 
-configs = require('configs')
+configs = dofile('configs.lua')
 
 -- Start the database with sharding
 vshard = require('vshard')

--- a/test/multiple_routers/storage_1_1_a.lua
+++ b/test/multiple_routers/storage_1_1_a.lua
@@ -5,8 +5,8 @@ NAME = require('fio').basename(arg[0], '.lua')
 
 -- Fetch config for the cluster of the instance.
 if NAME:sub(9,9) == '1' then
-    cfg = require('configs').cfg_1
+    cfg = dofile('configs.lua').cfg_1
 else
-    cfg = require('configs').cfg_2
+    cfg = dofile('configs.lua').cfg_2
 end
 require('storage_template')

--- a/test/rebalancer/box_1_a.lua
+++ b/test/rebalancer/box_1_a.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env tarantool
 NAME = require('fio').basename(arg[0], '.lua')
-cfg = require('config')
+cfg = dofile('config.lua')
 util = require('util')
 if NAME == 'box_3_a' or NAME == 'box_3_b' or
    NAME == 'box_4_a' or NAME == 'box_4_b' or

--- a/test/rebalancer/router_1.lua
+++ b/test/rebalancer/router_1.lua
@@ -1,5 +1,5 @@
 #!/usr/bin/env tarantool
-cfg = require('config')
+cfg = dofile('config.lua')
 vshard = require('vshard')
 os = require('os')
 fiber = require('fiber')

--- a/test/router/box_1_a.lua
+++ b/test/router/box_1_a.lua
@@ -1,3 +1,3 @@
 #!/usr/bin/env tarantool
-cfg = require('config')
+cfg = dofile('config.lua')
 require('storage_template')

--- a/test/router/router_2.lua
+++ b/test/router/router_2.lua
@@ -1,5 +1,5 @@
 #!/usr/bin/env tarantool
-cfg = require('config')
+cfg = dofile('config.lua')
 cfg.listen = 3300
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')

--- a/test/router/router_3.lua
+++ b/test/router/router_3.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env tarantool
 fiber = require('fiber')
-cfg = require('config')
+cfg = dofile('config.lua')
 cfg.listen = 3300
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')


### PR DESCRIPTION
The main reason of this change is that we're going to introduce a new built-in module `config`. See https://github.com/tarantool/tarantool/issues/8724 for details.

Introducing a new module in the global namespace is legal according to our compatibility rules. Quoted from https://github.com/orgs/tarantool/discussions/6182:

> Adding a new built-in module or a new global value is considered as
> the compatible change.

Moreover, in the real-world applications configs may be changed and reloaded, so they likely will be loaded using dofile() or loadfile() without require()'s caching.