### PR TITLE
Config option to disable user management

### DIFF
--- a/test/storage-luatest/schema_management_mode_test.lua
+++ b/test/storage-luatest/schema_management_mode_test.lua
@@ -1,0 +1,79 @@
+local t = require('luatest')
+local vtest = require('test.luatest_helpers.vtest')
+local vutil = require('vshard.util')
+
+local group_config = {{mode = 'auto'}, {mode = 'manual_access'}}
+
+if vutil.feature.memtx_mvcc then
+    table.insert(group_config, {
+        mode = 'auto', memtx_use_mvcc_engine = true
+    })
+    table.insert(group_config, {
+        mode = 'manual_access', memtx_use_mvcc_engine = true
+    })
+end
+
+local test_group = t.group('storage_schema_management_mode', group_config)
+
+local cfg_template = {
+    sharding = {
+        {
+            master = 'auto',
+            replicas = {
+                replica_1_a = {read_only = false},
+                replica_1_b = {read_only = true},
+            },
+        },
+        {
+            master = 'auto',
+            replicas = {
+                replica_2_a = {read_only = false},
+            },
+        },
+    },
+    bucket_count = 10,
+}
+
+test_group.before_all(function(g)
+    cfg_template.memtx_use_mvcc_engine = g.params.memtx_use_mvcc_engine
+    cfg_template.schema_management_mode = g.params.mode
+    local cfg = vtest.config_new(cfg_template)
+
+    vtest.cluster_new(g, cfg)
+    vtest.cluster_bootstrap(g, cfg)
+    vtest.cluster_rebalancer_disable(g)
+end)
+
+test_group.after_all(function(g)
+    g.cluster:drop()
+    g.cluster = nil
+end)
+
+test_group.test_boot_with_mode_manual_access = function(g)
+    local bid = g.replica_1_a:exec(function(uuid)
+        local bid = _G.get_first_bucket()
+        local ok, err = ivshard.storage.bucket_send(bid, uuid,
+                                                    {timeout = iwait_timeout})
+        ilt.assert_equals(err, nil)
+        ilt.assert(ok)
+        _G.bucket_gc_wait()
+        return bid
+    end, {g.replica_2_a:replicaset_uuid()})
+    --
+    -- Switch to another mode. Still works fine.
+    --
+    local test_template = table.deepcopy(cfg_template)
+    if test_template.schema_management_mode == 'auto' then
+        test_template.schema_management_mode = 'manual_access'
+    else
+        test_template.schema_management_mode = 'auto'
+    end
+    vtest.cluster_cfg(g, vtest.config_new(test_template))
+    g.replica_2_a:exec(function(bid, uuid)
+        local ok, err = ivshard.storage.bucket_send(bid, uuid,
+                                                    {timeout = iwait_timeout})
+        ilt.assert_equals(err, nil)
+        ilt.assert(ok)
+        _G.bucket_gc_wait()
+    end, {bid, g.replica_1_a:replicaset_uuid()})
+end

--- a/test/storage-luatest/storage_1_test.lua
+++ b/test/storage-luatest/storage_1_test.lua
@@ -46,7 +46,7 @@ end)
 test_group.test_sharded_spaces = function(g)
     g.replica_1_a:exec(function(engine)
         ilt.assert_not_equals(engine, nil)
-        local vinternal = ivshard.storage.internal
+        local vschema = require('vshard.storage.schema')
         --
         -- gh-96: public API to see all sharded spaces.
         --
@@ -75,10 +75,10 @@ test_group.test_sharded_spaces = function(g)
         -- gh-74: allow to choose any name for shard indexes.
         --
         s1k:rename('vbuckets')
-        vinternal.shard_index = 'vbuckets'
+        vschema.shard_index = 'vbuckets'
         ilt.assert_items_equals(get_sharded_names(), {s1.name})
         s1k:rename('bucket_id_tmp')
-        vinternal.shard_index = 'bucket_id'
+        vschema.shard_index = 'bucket_id'
         ilt.assert_items_equals(get_sharded_names(), {})
         s1k:rename('bucket_id')
 
@@ -91,10 +91,10 @@ test_group.test_sharded_spaces = function(g)
         --
         -- gh-111: cache sharded spaces based on schema version
         --
-        local cached_spaces = vinternal.cached_find_sharded_spaces()
-        ilt.assert_is(cached_spaces, vinternal.cached_find_sharded_spaces())
+        local cached_spaces = vschema.find_sharded_spaces()
+        ilt.assert_is(cached_spaces, vschema.find_sharded_spaces())
         s1 = box.schema.create_space('test', {engine = engine})
-        ilt.assert_is_not(cached_spaces, vinternal.cached_find_sharded_spaces())
+        ilt.assert_is_not(cached_spaces, vschema.find_sharded_spaces())
         s1:drop()
     end, {g.params.engine})
 end

--- a/test/unit-luatest/config_test.lua
+++ b/test/unit-luatest/config_test.lua
@@ -299,4 +299,14 @@ g.test_enum = function()
         "Box.cfg mode must be enum {'auto', 'manual', nil}",
         vcfg.check, config)
     config.box_cfg_mode = nil
+
+    for _, v in pairs({'auto', 'manual_access'}) do
+        config.schema_management_mode = v
+        t.assert(vcfg.check(config))
+    end
+    config.schema_management_mode = 'bad'
+    t.assert_error_msg_content_equals(
+        "Schema management mode must be enum {'auto', 'manual_access', nil}",
+        vcfg.check, config)
+    config.schema_management_mode = nil
 end

--- a/test/unit-luatest/storage_exports_test.lua
+++ b/test/unit-luatest/storage_exports_test.lua
@@ -1,0 +1,98 @@
+local t = require('luatest')
+local server = require('test.luatest_helpers.server')
+local vutil = require('vshard.util')
+
+local group_config = {{}}
+
+if vutil.feature.memtx_mvcc then
+    table.insert(group_config, {memtx_use_mvcc_engine = true})
+end
+
+local test_group = t.group('storage_schema', group_config)
+
+test_group.before_all(function(g)
+    g.server = server:new({alias = 'node', box_cfg = {
+        memtx_use_mvcc_engine = g.params.memtx_use_mvcc_engine
+    }})
+    g.server:start()
+    g.server:exec(function()
+        rawset(_G, 'ivexports', require('vshard.storage.exports'))
+        rawset(_G, 'ivutil', require('vshard.util'))
+        rawset(_G, 'iversion', require('vshard.version'))
+        box.schema.user.create('storage', {password = 'storage'})
+    end)
+end)
+
+test_group.after_each(function(g)
+    -- Drop all the exports to keep the test cases isolated.
+    g.server:exec(function()
+        _G.ivexports.deploy_funcs(_G.ivexports.compile({
+            version = '0',
+            funcs = {},
+        }))
+    end)
+end)
+
+test_group.after_all(function(g)
+    g.server:stop()
+end)
+
+--
+-- Functions are created as expected. VShard upgrade works.
+--
+test_group.test_basic = function(g)
+    g.server:exec(function()
+        local exports = _G.ivexports.log[1]
+        exports = _G.ivexports.compile(exports)
+        _G.ivexports.deploy_funcs(exports)
+        for name, _ in pairs(exports.funcs) do
+            ilt.assert(box.schema.func.exists(name))
+        end
+        local func_name_index = box.space._func.index.name
+        local func_tuple = func_name_index:get('vshard.storage.bucket_recv')
+        ilt.assert(func_tuple)
+        ilt.assert_equals(func_tuple.setuid, 1)
+
+        func_tuple = func_name_index:get('vshard.storage._call')
+        ilt.assert_not(func_tuple)
+
+        exports = _G.ivexports.log[2]
+        exports = _G.ivexports.compile(exports)
+        _G.ivexports.deploy_funcs(exports)
+        for name, _ in pairs(exports.funcs) do
+            ilt.assert(box.schema.func.exists(name))
+        end
+        func_tuple = func_name_index:get('vshard.storage._call')
+        ilt.assert(func_tuple)
+    end)
+end
+
+--
+-- On core upgrade the exports can get an upgrade too, even if the vshard
+-- version didn't change.
+--
+test_group.test_core_upgrade = function(g)
+    t.run_only_if(vutil.version_is_at_least(2, 10, 0, 'beta', 2, 0))
+    g.server:exec(function()
+        local orig_version = _G.ivutil.core_version
+        _G.ivutil.core_version = _G.iversion.parse('1.10.0')
+        local raw_exports = _G.ivexports.log[#_G.ivexports.log]
+        local exports = _G.ivexports.compile(raw_exports)
+        _G.ivexports.deploy_funcs(exports)
+        for name, _ in pairs(exports.funcs) do
+            ilt.assert(box.schema.func.exists(name))
+        end
+
+        local func_name_index = box.space._func.index.name
+        local func_tuple = func_name_index:get('vshard.storage.bucket_recv')
+        ilt.assert(func_tuple)
+        ilt.assert_equals(func_tuple.setuid, 1)
+        ilt.assert_not(func_tuple.opts.takes_raw_args)
+
+        _G.ivutil.core_version = orig_version
+        exports = _G.ivexports.compile(raw_exports)
+        _G.ivexports.deploy_funcs(exports)
+        func_tuple = func_name_index:get('vshard.storage.bucket_recv')
+        ilt.assert(func_tuple.opts.takes_raw_args)
+    end)
+end

--- a/test/unit/upgrade.result
+++ b/test/unit/upgrade.result
@@ -20,24 +20,26 @@ _ = test_run:switch("newdefault")
 util = require('util')
  | ---
  | ...
-
+vschema = require('vshard.storage.schema')
+ | ---
+ | ...
 vshard = require('vshard')
  | ---
  | ...
 
-upgrade = vshard.storage.internal.schema_upgrade_master
+upgrade = vschema.upgrade
  | ---
  | ...
-handlers = vshard.storage.internal.schema_upgrade_handlers
+handlers = vschema.upgrade_handlers
  | ---
  | ...
-version_make = vshard.storage.internal.schema_version_make
+version_make = vschema.version_make
  | ---
  | ...
-curr_version = vshard.storage.internal.schema_current_version
+curr_version = vschema.current_version
  | ---
  | ...
-schema_bootstrap = vshard.storage.internal.schema_bootstrap
+schema_bootstrap = vschema.bootstrap_first_version
  | ---
  | ...
 
@@ -160,7 +162,7 @@ end;
 upgrade_trace = {};
  | ---
  | ...
-errinj = vshard.storage.internal.errinj;
+errinj = vschema.errinj;
  | ---
  | ...
 

--- a/test/unit/upgrade.test.lua
+++ b/test/unit/upgrade.test.lua
@@ -9,14 +9,14 @@ _ = test_run:cmd("start server newdefault")
 _ = test_run:switch("newdefault")
 
 util = require('util')
-
+vschema = require('vshard.storage.schema')
 vshard = require('vshard')
 
-upgrade = vshard.storage.internal.schema_upgrade_master
-handlers = vshard.storage.internal.schema_upgrade_handlers
-version_make = vshard.storage.internal.schema_version_make
-curr_version = vshard.storage.internal.schema_current_version
-schema_bootstrap = vshard.storage.internal.schema_bootstrap
+upgrade = vschema.upgrade
+handlers = vschema.upgrade_handlers
+version_make = vschema.version_make
+curr_version = vschema.current_version
+schema_bootstrap = vschema.bootstrap_first_version
 
 user = 'storage'
 password = 'storage'
@@ -100,7 +100,7 @@ function stat_update()
 end;
 
 upgrade_trace = {};
-errinj = vshard.storage.internal.errinj;
+errinj = vschema.errinj;
 
 for _, handler in pairs(handlers) do
     table.insert(upgrade_trace, string.format('Upgrade to %s', handler.version))

--- a/test/upgrade/upgrade.result
+++ b/test/upgrade/upgrade.result
@@ -68,12 +68,8 @@ test_run:switch('storage_1_a')
 if is_at_least_3_0 then                                                         \
     local t = box.space._schema:get{'vshard_version'}                           \
     assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
-    assert(vshard.storage.internal.schema_current_version ~= nil)               \
-    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
 else                                                                            \
     assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
-    assert(vshard.storage.internal.schema_current_version == nil)               \
-    assert(vshard.storage.internal.schema_latest_version == nil)                \
 end
  | ---
  | ...
@@ -102,12 +98,8 @@ test_run:switch('storage_2_a')
 if is_at_least_3_0 then                                                         \
     local t = box.space._schema:get{'vshard_version'}                           \
     assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
-    assert(vshard.storage.internal.schema_current_version ~= nil)               \
-    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
 else                                                                            \
     assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
-    assert(vshard.storage.internal.schema_current_version == nil)               \
-    assert(vshard.storage.internal.schema_latest_version == nil)                \
 end
  | ---
  | ...
@@ -158,15 +150,18 @@ test_run:switch('storage_1_a')
  | ---
  | - true
  | ...
+vschema = require('vshard.storage.schema')
+ | ---
+ | ...
 box.space._schema:get({'vshard_version'})
  | ---
  | - ['vshard_version', 0, 1, 16, 0]
  | ...
-vshard.storage.internal.schema_current_version()
+vschema.current_version()
  | ---
  | - '{0.1.16.0}'
  | ...
-vshard.storage.internal.schema_latest_version
+vschema.latest_version
  | ---
  | - '{0.1.16.0}'
  | ...
@@ -195,6 +190,9 @@ test_run:switch('storage_1_b')
  | ---
  | - true
  | ...
+vschema = require('vshard.storage.schema')
+ | ---
+ | ...
 test_run:wait_lsn('storage_1_b', 'storage_1_a')
  | ---
  | ...
@@ -202,11 +200,11 @@ box.space._schema:get({'vshard_version'})
  | ---
  | - ['vshard_version', 0, 1, 16, 0]
  | ...
-vshard.storage.internal.schema_current_version()
+vschema.current_version()
  | ---
  | - '{0.1.16.0}'
  | ...
-vshard.storage.internal.schema_latest_version
+vschema.latest_version
  | ---
  | - '{0.1.16.0}'
  | ...

--- a/test/upgrade/upgrade.test.lua
+++ b/test/upgrade/upgrade.test.lua
@@ -32,12 +32,8 @@ test_run:switch('storage_1_a')
 if is_at_least_3_0 then                                                         \
     local t = box.space._schema:get{'vshard_version'}                           \
     assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
-    assert(vshard.storage.internal.schema_current_version ~= nil)               \
-    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
 else                                                                            \
     assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
-    assert(vshard.storage.internal.schema_current_version == nil)               \
-    assert(vshard.storage.internal.schema_latest_version == nil)                \
 end
 
 bucket_count = vshard.consts.DEFAULT_BUCKET_COUNT / 2
@@ -51,12 +47,8 @@ test_run:switch('storage_2_a')
 if is_at_least_3_0 then                                                         \
     local t = box.space._schema:get{'vshard_version'}                           \
     assert(table.equals(t:totable(), {'vshard_version', 0, 1, 16, 0}))          \
-    assert(vshard.storage.internal.schema_current_version ~= nil)               \
-    assert(vshard.storage.internal.schema_latest_version ~= nil)                \
 else                                                                            \
     assert(box.space._schema:get{'oncevshard:storage:1'} ~= nil)                \
-    assert(vshard.storage.internal.schema_current_version == nil)               \
-    assert(vshard.storage.internal.schema_latest_version == nil)                \
 end
 bucket_count = vshard.consts.DEFAULT_BUCKET_COUNT / 2
 first_bucket = vshard.consts.DEFAULT_BUCKET_COUNT / 2 + 1
@@ -75,17 +67,19 @@ test_run:cmd('stop server storage_1_b')
 test_run:cmd('start server storage_1_b')
 
 test_run:switch('storage_1_a')
+vschema = require('vshard.storage.schema')
 box.space._schema:get({'vshard_version'})
-vshard.storage.internal.schema_current_version()
-vshard.storage.internal.schema_latest_version
+vschema.current_version()
+vschema.latest_version
 vshard.storage._call ~= nil
 vshard.storage._call('test_api', 1, 2, 3)
 
 test_run:switch('storage_1_b')
+vschema = require('vshard.storage.schema')
 test_run:wait_lsn('storage_1_b', 'storage_1_a')
 box.space._schema:get({'vshard_version'})
-vshard.storage.internal.schema_current_version()
-vshard.storage.internal.schema_latest_version
+vschema.current_version()
+vschema.latest_version
 vshard.storage._call ~= nil
 
 test_run:switch('default')

--- a/vshard/cfg.lua
+++ b/vshard/cfg.lua
@@ -410,7 +410,11 @@ local cfg_template = {
     box_cfg_mode = {
         name = 'Box.cfg mode', type = 'enum', is_optional = true,
         default = 'auto', enum = {'auto', 'manual'},
-    }
+    },
+    schema_management_mode = {
+        name = 'Schema management mode', type = 'enum',
+        is_optional = true, default = 'auto', enum = {'auto', 'manual_access'},
+    },
 }
 
 --

--- a/vshard/storage/CMakeLists.txt
+++ b/vshard/storage/CMakeLists.txt
@@ -1,2 +1,2 @@
-install(FILES init.lua reload_evolution.lua ref.lua sched.lua
+install(FILES init.lua reload_evolution.lua ref.lua sched.lua schema.lua
         DESTINATION ${TARANTOOL_INSTALL_LUADIR}/vshard/storage)

--- a/vshard/storage/CMakeLists.txt
+++ b/vshard/storage/CMakeLists.txt
@@ -1,2 +1,3 @@
 install(FILES init.lua reload_evolution.lua ref.lua sched.lua schema.lua
+        export_log.lua exports.lua
         DESTINATION ${TARANTOOL_INSTALL_LUADIR}/vshard/storage)

--- a/vshard/storage/export_log.lua
+++ b/vshard/storage/export_log.lua
@@ -1,0 +1,93 @@
+--
+-- Export log module provides all exports for all vshard schema versions. This
+-- is used by vshard itself to deploy the exports and can be used by external
+-- tools to do the same.
+--
+-- Note that it contains only the exports. Not the complete schema. I.e. there
+-- is no info about users and spaces and whatever else is not for direct usage
+-- by users and routers.
+--
+-- The export log has the format:
+--
+-- [
+--   {
+--     version = <vshard schema version str>,
+--     funcs = {
+--       <func name> = [
+--         {
+--           since_core = <since which core version the definition is used>,
+--           def = <argument for box.schema.func.create(def),
+--         },
+--         {
+--           since_core = <next core version str when the previous
+--                         definition changed>,
+--           ...
+--         },
+--         <next func defs for newer cores>
+--         ...
+--       ]
+--   },
+--   <next versions>
+--   ...
+--
+
+--------------------------------------------------------------------------------
+-- Version 0.1.15.0
+--------------------------------------------------------------------------------
+local version_0_1_15_0_func_names = {
+    'vshard.storage.sync',
+    'vshard.storage.call',
+    'vshard.storage.bucket_force_create',
+    'vshard.storage.bucket_force_drop',
+    'vshard.storage.bucket_collect',
+    'vshard.storage.bucket_send',
+    'vshard.storage.bucket_recv',
+    'vshard.storage.bucket_stat',
+    'vshard.storage.buckets_count',
+    'vshard.storage.buckets_info',
+    'vshard.storage.buckets_discovery',
+    'vshard.storage.rebalancer_request_state',
+    'vshard.storage.rebalancer_apply_routes',
+}
+local version_0_1_15_0_funcs = {}
+for _, name in pairs(version_0_1_15_0_func_names) do
+    version_0_1_15_0_funcs[name] = {
+        {since_core = '1.10.0', def = {setuid = true}}
+    }
+end
+--
+-- Make vshard.storage.bucket_recv() understand raw args as msgpack object. It
+-- doesn't necessarily make it faster, but is essential to preserve the original
+-- tuples as is, without their contortion through Lua tables. It would break
+-- field types like MP_BIN (varbinary).
+--
+table.insert(version_0_1_15_0_funcs['vshard.storage.bucket_recv'], {
+    since_core = '2.10.0-beta2',
+    def = {setuid = true, takes_raw_args = true}
+})
+local version_0_1_15_0 = {
+    version = '0.1.15.0',
+    funcs = version_0_1_15_0_funcs
+}
+
+--------------------------------------------------------------------------------
+-- Version 0.1.16.0
+--------------------------------------------------------------------------------
+local version_0_1_16_0 = table.deepcopy(version_0_1_15_0)
+version_0_1_16_0.version = '0.1.16.0'
+-- vshard.storage._call() is supposed to replace some internal functions exposed
+-- in _func; to allow introduction of new functions on replicas; to allow change
+-- of internal functions without touching the schema.
+version_0_1_16_0.funcs['vshard.storage._call'] = {
+    {since_core = '1.10.0', def = {setuid = true}}
+}
+-- Don't drop old functions in the same version. Removal can happen only after
+-- 0.1.16. Or there should appear support of rebalancing from too old versions.
+-- Drop of these functions now would immediately make it impossible to rebalance
+-- from old instances.
+
+--------------------------------------------------------------------------------
+return {
+    version_0_1_15_0,
+    version_0_1_16_0,
+}

--- a/vshard/storage/exports.lua
+++ b/vshard/storage/exports.lua
@@ -1,0 +1,165 @@
+--
+-- Exports module provides the export log and means to do various things with
+-- the exports. For example, to deploy them, or their grants, or other things
+-- around this theme.
+--
+local ljson = require('json')
+local llog = require('log')
+local lversion = require('vshard.version')
+local lvexport_log = require('vshard.storage.export_log')
+local lvutil = require('vshard.util')
+
+--
+-- Given the exports of a specific vshard version, build the final exports
+-- suitable for the current core version. The result format:
+--
+-- {
+--   vshard_version = <str>,
+--   core_version = <str>,
+--   funcs = [
+--     <func_name> = {
+--         since_core = <str>,
+--         def = <table to give to box.schema.func.create(name, def)>,
+--     },
+--     <next functions>
+--     ...
+--   ]
+-- }
+--
+local function exports_compile(exports)
+    local compiled_funcs = {}
+    for name, func_versions in pairs(exports.funcs) do
+        local target_version
+        for _, func_version in pairs(func_versions) do
+            local since_core = lversion.parse(func_version.since_core)
+            if lvutil.core_version < since_core then
+                break
+            end
+            target_version = func_version
+        end
+        if target_version then
+            compiled_funcs[name] = target_version
+        end
+    end
+    return {
+        vshard_version = exports.version,
+        core_version = table.concat(lvutil.core_version, '.'),
+        funcs = compiled_funcs,
+    }
+end
+
+--
+-- The exports must be already compiled. Then create the newly exported
+-- functions; delete the vshard functions not listed in the exports; modify the
+-- updated exported functions. The entire set of vshard functions becomes up to
+-- date with these exports like if they were deployed from scratch on an empty
+-- storage.
+--
+local function exports_deploy_funcs(exports)
+    llog.info('Deploying exports for vshard %s, core %s',
+              exports.vshard_version, exports.core_version)
+    local _func = box.space._func
+    local existing_funcs = {}
+    local to_drop_funcs = {}
+    local to_update_funcs = {}
+    for _, func_tuple in _func.index.name:pairs({'vshard.'},
+                                                {iterator = 'GE'}) do
+        local name = func_tuple.name
+        if not name:startswith('vshard') then
+            break
+        end
+        local func_export = exports.funcs[name]
+        if not func_export then
+            table.insert(to_drop_funcs, name)
+        else
+            existing_funcs[name] = true
+            local current_def = {
+                setuid = func_tuple.setuid == 1 and true or false,
+                takes_raw_args = (func_tuple.opts or {}).takes_raw_args,
+            }
+            local target_def = func_export.def
+            if not lvutil.table_equals(target_def, current_def) then
+                to_update_funcs[func_tuple.id] = {
+                    target = target_def,
+                    current = current_def,
+                    name = name,
+                }
+            end
+        end
+    end
+    --
+    -- Create.
+    --
+    local to_add_funcs = {}
+    for name, func_export in pairs(exports.funcs) do
+        if not existing_funcs[name] then
+            to_add_funcs[name] = func_export.def
+        end
+    end
+    for name, func_def in pairs(to_add_funcs) do
+        llog.info("Create function '%s': %s", name, ljson.encode(func_def))
+        box.schema.func.create(name, func_def)
+    end
+    --
+    -- Update.
+    --
+    for func_id, update_data in pairs(to_update_funcs) do
+        llog.info("Modify function '%s': from %s to %s", update_data.name,
+                  ljson.encode(update_data.current),
+                  ljson.encode(update_data.target))
+        -- Preserve all the possible grants which could be given to the
+        -- function. Don't just drop and re-create.
+        local _priv = box.space._priv
+        local privs = _priv.index.object:select{'function', func_id}
+        local priv_pk_parts = _priv.index.primary.parts
+
+        -- Extract the old function.
+        for _, p in pairs(privs) do
+            _priv:delete(lvutil.tuple_extract_key(p, priv_pk_parts))
+        end
+        local tuple = _func:delete(func_id)
+
+        -- Insert the updated version. Can't update it in-place, _func doesn't
+        -- support that.
+        for key, value in pairs(update_data.target) do
+            local location
+            if tuple[key] ~= nil then
+                location = key
+            else
+                location = ('opts.%s'):format(key)
+            end
+            -- In tuple this flag is expected to be an unsigned. Legacy which
+            -- has to be maintained now.
+            if key == 'setuid' then
+                value = value and 1 or 0
+            end
+            tuple = tuple:update({{'=', location, value}})
+            llog.info('Key update %s ok', key)
+        end
+        _func:insert(tuple)
+        for _, p in pairs(privs) do
+            _priv:insert(p)
+        end
+    end
+    --
+    -- Delete.
+    --
+    for _, name in pairs(to_drop_funcs) do
+        llog.info("Drop function '%s'", name)
+        box.schema.func.drop(name)
+    end
+end
+
+local function exports_deploy_privs(exports, username)
+    for name, _ in pairs(exports.funcs) do
+        box.schema.user.grant(username, 'execute', 'function', name,
+                              {if_not_exists = true})
+    end
+end
+
+return {
+    log = lvexport_log,
+    compile = exports_compile,
+    deploy_funcs = exports_deploy_funcs,
+    deploy_privs = exports_deploy_privs,
+}

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -19,7 +19,8 @@ if rawget(_G, MODULE_INTERNALS) then
         'vshard.replicaset', 'vshard.util', 'vshard.service_info',
         'vshard.storage.reload_evolution', 'vshard.rlist', 'vshard.registry',
         'vshard.heap', 'vshard.storage.ref', 'vshard.storage.sched',
-        'vshard.storage.schema'
+        'vshard.storage.schema', 'vshard.storage.export_log',
+        'vshard.storage.exports'
     }
     for _, module in pairs(vshard_modules) do
         package.loaded[module] = nil

--- a/vshard/storage/schema.lua
+++ b/vshard/storage/schema.lua
@@ -1,0 +1,334 @@
+local llog = require('log')
+local lutil = require('vshard.util')
+
+local MODULE_INTERNALS = '__module_vshard_storage_schema'
+-- Update when change behaviour of anything in the file, to be able to reload.
+local MODULE_VERSION = 1
+
+local M = rawget(_G, MODULE_INTERNALS)
+if not M then
+    M = {
+        ----------------------- Common module attributes -----------------------
+        module_version = MODULE_VERSION,
+        -- Flag whether Tarantool core version was already checked and the
+        -- schema is up to date with this version.
+        is_core_up_to_date = false,
+        -- Index which is a trigger to shard its space by numbers in this index.
+        -- It must have at first part either unsigned, or integer or number type
+        -- and be not nullable. Values in this part are considered as bucket
+        -- identifiers.
+        shard_index = nil,
+        errinj = {
+            ERRINJ_UPGRADE = false,
+        },
+    }
+else
+    return M
+end
+
+local schema_version_mt = {
+    __tostring = function(self)
+        return string.format('{%s}', table.concat(self, '.'))
+    end,
+    __serialize = function(self)
+        return tostring(self)
+    end,
+    __eq = function(l, r)
+        return l[1] == r[1] and l[2] == r[2] and l[3] == r[3] and l[4] == r[4]
+    end,
+    __lt = function(l, r)
+        for i = 1, 4 do
+            local diff = l[i] - r[i]
+            if diff < 0 then
+                return true
+            elseif diff > 0 then
+                return false
+            end
+        end
+        return false
+    end,
+}
+
+local function schema_version_make(ver)
+    return setmetatable(ver, schema_version_mt)
+end
+
+--
+-- VShard versioning works in 4 numbers: major, minor, patch, and a last helper
+-- number incremented on every schema change, if first 3 numbers stay not
+-- changed. That happens when users take the latest master version not having a
+-- tag yet. They couldn't upgrade if not the 4th number changed inside one tag.
+
+-- The schema first time appeared with 0.1.16. So this function describes schema
+-- before that - 0.1.15.
+--
+local function schema_init_0_1_15_0(username, password)
+    llog.info("Initializing schema %s", schema_version_make({0, 1, 15, 0}))
+    box.schema.user.create(username, {
+        password = password,
+        if_not_exists = true,
+    })
+    box.schema.user.grant(username, 'replication', nil, nil,
+                          {if_not_exists = true})
+
+    local bucket = box.schema.space.create('_bucket')
+    bucket:format({
+        {'id', 'unsigned'},
+        {'status', 'string'},
+        {'destination', 'string', is_nullable = true}
+    })
+    bucket:create_index('pk', {parts = {'id'}})
+    bucket:create_index('status', {parts = {'status'}, unique = false})
+
+    local storage_api = {
+        'vshard.storage.sync',
+        'vshard.storage.call',
+        'vshard.storage.bucket_force_create',
+        'vshard.storage.bucket_force_drop',
+        'vshard.storage.bucket_collect',
+        'vshard.storage.bucket_send',
+        'vshard.storage.bucket_recv',
+        'vshard.storage.bucket_stat',
+        'vshard.storage.buckets_count',
+        'vshard.storage.buckets_info',
+        'vshard.storage.buckets_discovery',
+        'vshard.storage.rebalancer_request_state',
+        'vshard.storage.rebalancer_apply_routes',
+    }
+    for _, name in ipairs(storage_api) do
+        box.schema.func.create(name, {setuid = true})
+        box.schema.user.grant(username, 'execute', 'function', name)
+    end
+    box.space._schema:replace({'vshard_version', 0, 1, 15, 0})
+end
+
+local function schema_upgrade_to_0_1_16_0(username)
+    -- Since 0.1.16.0 the old versioning by 'oncevshard:storage:<number>' is
+    -- dropped because it is not really extendible nor understandable.
+    llog.info("Insert 'vshard_version' into _schema")
+    box.space._schema:replace({'vshard_version', 0, 1, 16, 0})
+    box.space._schema:delete({'oncevshard:storage:1'})
+
+    -- vshard.storage._call() is supposed to replace some internal functions
+    -- exposed in _func; to allow introduction of new functions on replicas; to
+    -- allow change of internal functions without touching the schema.
+    local func = 'vshard.storage._call'
+    llog.info('Create function %s()', func)
+    box.schema.func.create(func, {setuid = true})
+    box.schema.user.grant(username, 'execute', 'function', func)
+    -- Don't drop old functions in the same version. Removal can happen only
+    -- after 0.1.16. Or there should appear support of rebalancing from too old
+    -- versions. Drop of these functions now would immediately make it
+    -- impossible to rebalance from old instances.
+end
+
+local function schema_downgrade_from_0_1_16_0()
+    llog.info("Remove 'vshard_version' from _schema")
+    box.space._schema:replace({'oncevshard:storage:1'})
+    box.space._schema:delete({'vshard_version'})
+
+    local func = 'vshard.storage._call'
+    llog.info('Remove function %s()', func)
+    box.schema.func.drop(func, {if_exists = true})
+end
+
+--
+-- Make vshard.storage.bucket_recv() understand raw args as msgpack object. It
+-- doesn't necessarily make it faster, but is essential to preserve the original
+-- tuples as is, without their contortion through Lua tables. It would break
+-- field types like MP_BIN (varbinary).
+--
+local function schema_upgrade_bucket_recv_raw()
+    if not lutil.feature.msgpack_object then
+        return
+    end
+    if box.func == nil then
+        return
+    end
+    local name = 'vshard.storage.bucket_recv'
+    local func = box.func[name]
+    if func == nil then
+        return
+    end
+    if func.takes_raw_args then
+        return
+    end
+    llog.info("Upgrade %s to accept args as msgpack", name)
+    box.begin()
+    local ok, err = pcall(function()
+        -- Preserve all the possible grants which could be given to the
+        -- function. Don't just drop and re-create.
+        local priv_space = box.space._priv
+        local func_space = box.space._func
+        local privs = priv_space.index.object:select{'function', func.id}
+        local priv_pk_parts = priv_space.index.primary.parts
+
+        -- Extract the old function.
+        for _, p in pairs(privs) do
+            priv_space:delete(lutil.tuple_extract_key(p, priv_pk_parts))
+        end
+        local tuple = func_space:delete(func.id)
+
+        -- Insert the updated version. Can't update it in-place, _func doesn't
+        -- support that.
+        tuple = tuple:update({{'=', 'opts.takes_raw_args', true}})
+        func_space:insert(tuple)
+        for _, p in pairs(privs) do
+            priv_space:insert(p)
+        end
+    end)
+    if ok then
+        ok, err = pcall(box.commit)
+        if ok then
+            return
+        end
+    end
+    box.rollback()
+    llog.error("Couldn't upgrade %s to accept args as msgpack: %s", name, err)
+end
+
+--
+-- Upgrade schema features which depend on Tarantool version and are not bound
+-- to a certain vshard version.
+--
+local function schema_upgrade_core_features()
+    -- Core features can only change with Tarantool exe update, which means it
+    -- won't happen on reconfig nor on hot reload. Enough to do it when
+    -- configured first time.
+    if M.is_core_up_to_date then
+        return
+    end
+    -- In future it could make sense to store core feature set version in
+    -- addition to vshard own schema version, but it would be an overkill while
+    -- the feature is just one.
+    schema_upgrade_bucket_recv_raw()
+    M.is_core_up_to_date = true
+end
+
+local function schema_current_version()
+    local version = box.space._schema:get({'vshard_version'})
+    if version == nil then
+        return schema_version_make({0, 1, 15, 0})
+    else
+        return schema_version_make(version:totable(2))
+    end
+end
+
+local schema_latest_version = schema_version_make({0, 1, 16, 0})
+
+-- Every handler should be atomic. It is either applied whole, or not applied at
+-- all. Atomic upgrade helps to downgrade in case something goes wrong. At least
+-- by doing restart with the latest successfully applied version. However,
+-- atomicity does not prohibit yields, in case the upgrade, for example, affects
+-- huge number of tuples (_bucket records, maybe).
+local schema_upgrade_handlers = {
+    {
+        version = schema_version_make({0, 1, 16, 0}),
+        upgrade = schema_upgrade_to_0_1_16_0,
+        downgrade = schema_downgrade_from_0_1_16_0
+    },
+}
+
+local function schema_upgrade(target_version, username, password)
+    local _schema = box.space._schema
+    local is_old_versioning = _schema:get({'oncevshard:storage:1'}) ~= nil
+    local version = schema_current_version()
+    local is_bootstrap = not box.space._bucket
+
+    if is_bootstrap then
+        schema_init_0_1_15_0(username, password)
+    elseif is_old_versioning then
+        llog.info("The instance does not have 'vshard_version' record. "..
+                  "It is 0.1.15.0.")
+    end
+    assert(schema_upgrade_handlers[#schema_upgrade_handlers].version ==
+           schema_latest_version)
+    local prev_version = version
+    local ok, err1, err2
+    local errinj = M.errinj.ERRINJ_UPGRADE
+    for _, handler in pairs(schema_upgrade_handlers) do
+        local next_version = handler.version
+        if next_version > target_version then
+            break
+        end
+        if next_version > version then
+            llog.info("Upgrade vshard schema to %s", next_version)
+            if errinj == 'begin' then
+                ok, err1 = false, 'Errinj in begin'
+            else
+                ok, err1 = pcall(handler.upgrade, username)
+                if ok and errinj == 'end' then
+                    ok, err1 = false, 'Errinj in end'
+                end
+            end
+            if not ok then
+                -- Rollback in case the handler started a transaction before the
+                -- exception.
+                box.rollback()
+                llog.info("Couldn't upgrade schema to %s: '%s'. Revert to %s",
+                          next_version, err1, prev_version)
+                ok, err2 = pcall(handler.downgrade)
+                if not ok then
+                    llog.info("Couldn't downgrade schema to %s - fatal error: "..
+                              "'%s'", prev_version, err2)
+                    os.exit(-1)
+                end
+                error(err1)
+            end
+            ok, err1 = pcall(_schema.replace, _schema,
+                             {'vshard_version', unpack(next_version)})
+            if not ok then
+                llog.info("Upgraded schema to %s but couldn't update _schema "..
+                          "'vshard_version' - fatal error: '%s'", next_version,
+                          err1)
+                os.exit(-1)
+            end
+            llog.info("Successful vshard schema upgrade to %s", next_version)
+        end
+        prev_version = next_version
+    end
+    schema_upgrade_core_features()
+end
+
+--
+-- Find spaces with index having the specified (in cfg) name. The function
+-- result is cached using `schema_version`.
+-- @retval Map of type {space_id = <space object>}.
+--
+local sharded_spaces_cache_schema_version = nil
+local sharded_spaces_cache = nil
+local function find_sharded_spaces()
+    local schema_version = lutil.schema_version()
+    if sharded_spaces_cache_schema_version == schema_version then
+        return sharded_spaces_cache
+    end
+    local spaces = {}
+    local idx = M.shard_index
+    for k, space in pairs(box.space) do
+        if type(k) == 'number' and space.index[idx] ~= nil then
+            local parts = space.index[idx].parts
+            local p = parts[1].type
+            if p == 'unsigned' or p == 'integer' or p == 'number' then
+                spaces[k] = space
+            end
+        end
+    end
+    sharded_spaces_cache_schema_version = schema_version
+    sharded_spaces_cache = spaces
+    return spaces
+end
+
+local function schema_cfg(cfg)
+    M.shard_index = cfg.shard_index
+end
+
+M.current_version = schema_current_version
+M.find_sharded_spaces = find_sharded_spaces
+M.latest_version = schema_latest_version
+M.upgrade = schema_upgrade
+M.upgrade_handlers = schema_upgrade_handlers
+M.version_make = schema_version_make
+M.bootstrap_first_version = schema_init_0_1_15_0
+M.cfg = schema_cfg
+
+return M

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -418,6 +418,7 @@ else
 end
 
 return {
+    core_version = tnt_version,
     uri_eq = uri_eq,
     tuple_extract_key = tuple_extract_key,
     reloadable_fiber_create = reloadable_fiber_create,
@@ -429,6 +430,7 @@ return {
     table_copy_yield = table_copy_yield,
     table_minus_yield = table_minus_yield,
     table_extend = table_extend,
+    table_equals = table_equals,
     fiber_cond_wait = fiber_cond_wait,
     fiber_is_self_canceled = fiber_is_self_canceled,
     index_min = index_min,


### PR DESCRIPTION
The patch introduces a new option `schema_management_mode` which allows to turn off automatic access management (users, grants, function exports). It also adds helper functions for exports deploy.

Closes #435.