### PR TITLE
Fix for working with ipv6 addrs in cartridge

### DIFF
--- a/test/replicaset-luatest/replicaset_3_test.lua
+++ b/test/replicaset-luatest/replicaset_3_test.lua
@@ -300,3 +300,13 @@ test_group.test_named_replicaset = function(g)
     t.assert_equals(ret, nil)
     vtest.storage_start(g.replica_1_b, global_cfg)
 end
+
+test_group.test_ipv6_uri = function(g)
+    local new_cfg = table.deepcopy(global_cfg)
+    local rs_uuid = g.replica_1_a:replicaset_uuid()
+    local uuid = g.replica_1_a:instance_uuid()
+    new_cfg.sharding[rs_uuid].replicas[uuid].uri = 'storage:storage@[::1]:3301'
+    local _, rs = next(vreplicaset.buildall(new_cfg))
+    local replica_string = 'replica_1_a(storage@[::1]:3301)'
+    t.assert_equals(tostring(rs.master), replica_string)
+end

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -1204,7 +1204,7 @@ local replica_mt = {
         safe_uri = function(replica)
             local uri = luri.parse(replica.uri)
             uri.password = nil
-            return luri.format(uri)
+            return util.uri_format(uri)
         end,
         detach_conn = replica_detach_conn,
     },

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -418,6 +418,22 @@ else
     end
 end
 
+local uri_v6_str = "[::1]:80"
+local uri_format
+-- URI module format() function doesn't behave correctly for IPv6 addresses on
+-- some Tarantool versions (all <= 3.0). In fact, at the time of writing none of
+-- the versions have this bug fixed.
+if luri.format(luri.parse(uri_v6_str)) ~= uri_v6_str then
+    uri_format = function(u)
+        if u.ipv6 then
+            u.host = '[' .. u.host .. ']'
+        end
+        return luri.format(u)
+    end
+else
+    uri_format = luri.format
+end
+
 return {
     core_version = tnt_version,
     uri_eq = uri_eq,
@@ -439,4 +455,5 @@ return {
     feature = feature,
     schema_version = schema_version,
     replicaset_uuid = replicaset_uuid,
+    uri_format = uri_format,
 }


### PR DESCRIPTION
Changes a needed to support ipv6 in cartridge

This changes needed for https://github.com/tarantool/cartridge/pull/2166