### PR TITLE
router: revert dropping box.cfg and introduce `box_cfg_mode`

### DIFF
--- a/example/router.lua
+++ b/example/router.lua
@@ -14,13 +14,11 @@ replicasets = {'cbf06940-0790-498b-948d-042b62cf3d29',
 
 -- Call a configuration provider
 cfg = dofile('localcfg.lua')
--- vshard.router.cfg doesn't support box.cfg options.
-cfg = require('vshard.cfg').extract_vshard(cfg)
 if arg[1] == 'discovery_disable' then
     cfg.discovery_mode = 'off'
 end
+cfg.listen = 3300
 
-box.cfg{listen = 3300}
 -- Start the database with sharding
 vshard = require('vshard')
 vshard.router.cfg(cfg)

--- a/test/failover/cluster_changes.result
+++ b/test/failover/cluster_changes.result
@@ -54,7 +54,7 @@ test_run:switch('router_1')
 -- First test case: reverse weights, when only replica exists,
 -- and no replica candidate.
 --
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 wait_state('All replicas are ok')
@@ -67,7 +67,7 @@ vshard.router.info().alerts
 reverse_weights()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 vshard.router.info()
@@ -274,7 +274,7 @@ test_run:switch('router_1')
 remove_some_replicas()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 info = vshard.router.info()
@@ -370,7 +370,7 @@ test_run:switch('router_1')
 add_some_replicas()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 #vshard.router.info().alerts > 1

--- a/test/failover/cluster_changes.test.lua
+++ b/test/failover/cluster_changes.test.lua
@@ -28,12 +28,12 @@ test_run:switch('router_1')
 -- First test case: reverse weights, when only replica exists,
 -- and no replica candidate.
 --
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 wait_state('All replicas are ok')
 vshard.router.info().alerts
 
 reverse_weights()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 vshard.router.info()
 wait_state('All replicas are ok')
 vshard.router.info()
@@ -71,7 +71,7 @@ vshard.storage.cfg(cfg, names.replica_uuid[NAME])
 --
 test_run:switch('router_1')
 remove_some_replicas()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 info = vshard.router.info()
 while #info.alerts ~= 6 do fiber.sleep(0.1) info = vshard.router.info() end
 info
@@ -90,7 +90,7 @@ vshard.storage.cfg(cfg, names.replica_uuid[NAME])
 --
 test_run:switch('router_1')
 add_some_replicas()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 #vshard.router.info().alerts > 1
 wait_state('All replicas are ok')
 vshard.router.info()

--- a/test/failover/failover.result
+++ b/test/failover/failover.result
@@ -102,7 +102,7 @@ test_run:switch('router_1')
 ---
 - true
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 while not test_run:grep_log('router_1', 'New replica box_1_d%(storage%@') do fiber.sleep(0.1) end
@@ -356,7 +356,7 @@ test_run:switch('router_2')
 ---
 - true
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 priority_order()
@@ -394,7 +394,7 @@ test_run:switch('router_3')
 ---
 - true
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 priority_order()
@@ -432,7 +432,7 @@ test_run:switch('router_4')
 ---
 - true
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 priority_order()
@@ -473,7 +473,7 @@ log.info(string.rep('padding', 200))
 cfg.failover_ping_timeout = 0.0000001
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 while not test_run:grep_log('router_1', 'Ping error from', 1000) do fiber.sleep(0.01) end
@@ -511,7 +511,7 @@ err
 cfg.failover_ping_timeout = nil
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 test_run:switch('default')

--- a/test/failover/failover.test.lua
+++ b/test/failover/failover.test.lua
@@ -52,7 +52,7 @@ test_run:cmd('switch default')
 --
 create_router('router_1')
 test_run:switch('router_1')
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 while not test_run:grep_log('router_1', 'New replica box_1_d%(storage%@') do fiber.sleep(0.1) end
 priority_order()
 vshard.router.bucket_discovery(1).uuid == rs_uuid[1]
@@ -143,7 +143,7 @@ test_run:switch('default')
 
 create_router('router_2')
 test_run:switch('router_2')
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 priority_order()
 vshard.router.bucket_discovery(1).uuid == rs_uuid[1]
 vshard.router.bucket_discovery(31).uuid == rs_uuid[2]
@@ -152,7 +152,7 @@ test_run:switch('default')
 
 create_router('router_3')
 test_run:switch('router_3')
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 priority_order()
 vshard.router.bucket_discovery(1).uuid == rs_uuid[1]
 vshard.router.bucket_discovery(31).uuid == rs_uuid[2]
@@ -161,7 +161,7 @@ test_run:switch('default')
 
 create_router('router_4')
 test_run:switch('router_4')
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 priority_order()
 vshard.router.bucket_discovery(1).uuid == rs_uuid[1]
 vshard.router.bucket_discovery(31).uuid == rs_uuid[2]
@@ -174,7 +174,7 @@ vshard.router.bucket_discovery(61).uuid == rs_uuid[3]
 test_run:switch('router_1')
 log.info(string.rep('padding', 200))
 cfg.failover_ping_timeout = 0.0000001
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 while not test_run:grep_log('router_1', 'Ping error from', 1000) do fiber.sleep(0.01) end
 
 t = string.rep('a', 1024 * 1024 * 500)
@@ -187,7 +187,7 @@ res, err = future:wait_result(5)
 err
 #res[1]
 cfg.failover_ping_timeout = nil
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 
 test_run:switch('default')
 kill_router('router_1')

--- a/test/failover/failover_errinj.result
+++ b/test/failover/failover_errinj.result
@@ -43,7 +43,7 @@ test_run:switch('router_1')
 ---
 - true
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 -- Check that already run failover step is restarted on

--- a/test/failover/failover_errinj.test.lua
+++ b/test/failover/failover_errinj.test.lua
@@ -16,7 +16,7 @@ test_run:cmd('create server router_1 with script="failover/router_1.lua"')
 test_run:cmd('start server router_1')
 test_run:switch('router_1')
 
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 -- Check that already run failover step is restarted on
 -- configuration change (if some replicasets are removed from
 -- config).

--- a/test/failover/router_1.lua
+++ b/test/failover/router_1.lua
@@ -11,7 +11,6 @@ os = require('os')
 fiber = require('fiber')
 local names = dofile('names.lua')
 log = require('log')
-util = require('util')
 rs_uuid = names.rs_uuid
 replica_uuid = names.replica_uuid
 local port

--- a/test/lua_libs/util.lua
+++ b/test/lua_libs/util.lua
@@ -215,23 +215,6 @@ local function map_bucket_protection(test_run, cluster, value)
         [[vshard.storage.internal.is_bucket_protected = ...]], value)
 end
 
-local function box_router_cfg(cfg, router)
-    local vcfg = require('vshard.cfg')
-    local vshard_cfg = vcfg.extract_vshard(cfg)
-    local box_cfg = vcfg.extract_box(cfg, {})
-    box.cfg(box_cfg)
-    if router == nil then
-        -- Static router configuration
-        return vshard.router.cfg(vshard_cfg)
-    end
-    if type(router) == 'table' then
-        -- Named router reconfiguration
-        return router:cfg(vshard_cfg)
-    end
-    -- Named router creation
-    return vshard.router.new(router, vshard_cfg)
-end
-
 return {
     check_error = check_error,
     shuffle_masters = shuffle_masters,
@@ -248,5 +231,4 @@ return {
     git_checkout = git_checkout,
     portable_error = portable_error,
     is_timeout_error = is_timeout_error,
-    box_router_cfg = box_router_cfg,
 }

--- a/test/luatest_helpers/server.lua
+++ b/test/luatest_helpers/server.lua
@@ -303,7 +303,8 @@ function Server:grep_log(what, bytes, opts)
                     line = table.concat(buf)
                     buf = nil
                 end
-                if string.match(line, "Starting instance") and not noreset then
+                local pattern = "Starting .*reconfiguration"
+                if string.match(line, pattern) and not noreset then
                     found = nil -- server was restarted, reset search
                 else
                     found = string.match(line, what) or found

--- a/test/misc/bad_uuid_router.lua
+++ b/test/misc/bad_uuid_router.lua
@@ -5,6 +5,7 @@ require('console').listen(os.getenv('ADMIN'))
 
 -- Call a configuration provider
 cfg = require('bad_uuid_config').cfg
+cfg.listen = 3300
 
 -- Start the database with sharding
 vshard = require('vshard')

--- a/test/misc/reconfigure.result
+++ b/test/misc/reconfigure.result
@@ -209,9 +209,9 @@ cfg.collect_lua_garbage = true
 cfg.invalid_option = 'kek'
 ---
 ...
-string.match(require('util').check_error(vshard.router.cfg, cfg, 'invalid_option'), 'Unrecognized cfg options')
+vshard.router.cfg(cfg)
 ---
-- Unrecognized cfg options
+- error: 'Incorrect value for option ''invalid_option'': unexpected option'
 ...
 not vshard.router.static.collect_lua_garbage
 ---

--- a/test/misc/reconfigure.test.lua
+++ b/test/misc/reconfigure.test.lua
@@ -87,7 +87,7 @@ _ = test_run:switch('router_1')
 not vshard.router.static.collect_lua_garbage
 cfg.collect_lua_garbage = true
 cfg.invalid_option = 'kek'
-string.match(require('util').check_error(vshard.router.cfg, cfg, 'invalid_option'), 'Unrecognized cfg options')
+vshard.router.cfg(cfg)
 not vshard.router.static.collect_lua_garbage
 cfg.invalid_option = nil
 cfg.collect_lua_garbage = nil

--- a/test/multiple_routers/multiple_routers.result
+++ b/test/multiple_routers/multiple_routers.result
@@ -55,7 +55,7 @@ test_run:cmd("start server router_1")
 _ = test_run:cmd("switch router_1")
 ---
 ...
-util.box_router_cfg(configs.cfg_1)
+vshard.router.cfg(configs.cfg_1)
 ---
 ...
 vshard.router.bootstrap()
@@ -85,7 +85,7 @@ vshard.router.static:route(1) == vshard.router.route(1)
 - true
 ...
 -- Configure extra router.
-router_2 = util.box_router_cfg(configs.cfg_2, 'router_2')
+router_2 = vshard.router.new('router_2', configs.cfg_2)
 ---
 ...
 router_2:bootstrap()
@@ -118,7 +118,7 @@ router_2:call(1, 'read', 'do_select', {2})
 routers = {}
 ---
 ...
-for i = 3, 10 do routers[i] = util.box_router_cfg(configs.cfg_2, 'router_' .. i) end
+for i = 3, 10 do routers[i] = vshard.router.new('router_' .. i, configs.cfg_2) end
 ---
 ...
 routers[3]:call(1, 'read', 'do_select', {2})
@@ -147,7 +147,7 @@ next(fiber_names) == nil
 - true
 ...
 -- Reconfigure one of routers do not affect the others.
-util.box_router_cfg(configs.cfg_1, routers[3])
+routers[3]:cfg(configs.cfg_1)
 ---
 ...
 routers[3]:call(1, 'read', 'do_select', {1})
@@ -166,11 +166,14 @@ routers[4]:call(1, 'read', 'do_select', {2})
 ---
 - [[2, 2]]
 ...
-util.box_router_cfg(configs.cfg_2, routers[3])
+routers[3]:cfg(configs.cfg_2)
 ---
 ...
 -- Try to create router with the same name.
-util.box_router_cfg(configs.cfg_2, 'router_2')
+util = require('util')
+---
+...
+util.check_error(vshard.router.new, 'router_2', configs.cfg_2)
 ---
 - null
 - code: 21

--- a/test/multiple_routers/router_1.lua
+++ b/test/multiple_routers/router_1.lua
@@ -12,5 +12,4 @@ configs = dofile('configs.lua')
 
 -- Start the database with sharding
 vshard = require('vshard')
-util = require('util')
 box.cfg{}

--- a/test/rebalancer/restart_during_rebalancing.result
+++ b/test/rebalancer/restart_during_rebalancing.result
@@ -67,7 +67,7 @@ add_replicaset()
 add_second_replicaset()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 --

--- a/test/rebalancer/restart_during_rebalancing.test.lua
+++ b/test/rebalancer/restart_during_rebalancing.test.lua
@@ -23,7 +23,7 @@ test_run:cmd('start server router_1')
 test_run:switch('router_1')
 add_replicaset()
 add_second_replicaset()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 
 --
 -- Test on the storages restarts during intensive loading and

--- a/test/rebalancer/router_1.lua
+++ b/test/rebalancer/router_1.lua
@@ -3,9 +3,8 @@ cfg = dofile('config.lua')
 vshard = require('vshard')
 os = require('os')
 fiber = require('fiber')
-util = require('util')
 
 box.cfg{listen = 3333}
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 
 require('console').listen(os.getenv('ADMIN'))

--- a/test/rebalancer/stress_add_remove_rs.result
+++ b/test/rebalancer/stress_add_remove_rs.result
@@ -81,16 +81,16 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util = require('rebalancer_utils')
+util = require('rebalancer_utils')
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 vshard.router.discovery_wakeup()
 ---
 ...
-rebalancer_util.start_loading()
+util.start_loading()
 ---
 ...
 test_run:switch('default')
@@ -165,7 +165,7 @@ test_run:switch('router_1')
 add_replicaset()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
@@ -186,10 +186,10 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.stop_loading()
+util.stop_loading()
 ---
 ...
-rebalancer_util.check_loading_result()
+util.check_loading_result()
 ---
 - true
 ...
@@ -240,7 +240,7 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.start_loading()
+util.start_loading()
 ---
 ...
 test_run:switch('box_3_a')
@@ -328,7 +328,7 @@ test_run:switch('router_1')
 remove_replicaset_first_stage()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
@@ -345,10 +345,10 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.stop_loading()
+util.stop_loading()
 ---
 ...
-rebalancer_util.check_loading_result()
+util.check_loading_result()
 ---
 - true
 ...
@@ -394,7 +394,7 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.start_loading()
+util.start_loading()
 ---
 ...
 test_run:switch('box_2_a')
@@ -463,13 +463,13 @@ test_run:switch('router_1')
 remove_replicaset_second_stage()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
-rebalancer_util.stop_loading()
+util.stop_loading()
 ---
 ...
-rebalancer_util.check_loading_result()
+util.check_loading_result()
 ---
 - true
 ...

--- a/test/rebalancer/stress_add_remove_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_rs.test.lua
@@ -37,10 +37,10 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 -- Test the first case of described above.
 --
 test_run:switch('router_1')
-rebalancer_util = require('rebalancer_utils')
-util.box_router_cfg(cfg)
+util = require('rebalancer_utils')
+vshard.router.cfg(cfg)
 vshard.router.discovery_wakeup()
-rebalancer_util.start_loading()
+util.start_loading()
 
 test_run:switch('default')
 test_run:create_cluster(REPLICASET_3, 'rebalancer')
@@ -65,15 +65,15 @@ fiber.sleep(0.5)
 
 test_run:switch('router_1')
 add_replicaset()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
 
 test_run:switch('box_1_a')
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 test_run:switch('router_1')
-rebalancer_util.stop_loading()
-rebalancer_util.check_loading_result()
+util.stop_loading()
+util.check_loading_result()
 
 test_run:switch('box_1_a')
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
@@ -95,7 +95,7 @@ check_consistency()
 -- out.
 --
 test_run:switch('router_1')
-rebalancer_util.start_loading()
+util.start_loading()
 test_run:switch('box_3_a')
 remove_replicaset_first_stage()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_3_a)
@@ -128,15 +128,15 @@ fiber.sleep(0.5)
 
 test_run:switch('router_1')
 remove_replicaset_first_stage()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
 
 test_run:switch('box_1_a')
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 
 test_run:switch('router_1')
-rebalancer_util.stop_loading()
-rebalancer_util.check_loading_result()
+util.stop_loading()
+util.check_loading_result()
 
 test_run:switch('box_1_a')
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
@@ -153,7 +153,7 @@ check_consistency()
 -- When buckets are moved out from third replicaset, remove it
 -- from config.
 test_run:switch('router_1')
-rebalancer_util.start_loading()
+util.start_loading()
 test_run:switch('box_2_a')
 remove_replicaset_second_stage()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
@@ -178,9 +178,9 @@ test_run:switch('default')
 test_run:drop_cluster(REPLICASET_3)
 test_run:switch('router_1')
 remove_replicaset_second_stage()
-util.box_router_cfg(cfg)
-rebalancer_util.stop_loading()
-rebalancer_util.check_loading_result()
+vshard.router.cfg(cfg)
+util.stop_loading()
+util.check_loading_result()
 alerts = vshard.router.info().alerts
 for _, a in ipairs(alerts) do assert(a[1] == 'SUBOPTIMAL_REPLICA' or a[1] == 'UNKNOWN_BUCKETS') end
 

--- a/test/rebalancer/stress_add_remove_several_rs.result
+++ b/test/rebalancer/stress_add_remove_several_rs.result
@@ -87,16 +87,16 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util = require('rebalancer_utils')
+util = require('rebalancer_utils')
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 vshard.router.discovery_wakeup()
 ---
 ...
-rebalancer_util.start_loading()
+util.start_loading()
 ---
 ...
 -- At first, add one replicaset.
@@ -159,7 +159,7 @@ test_run:switch('router_1')
 add_replicaset()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
@@ -277,7 +277,7 @@ test_run:switch('router_1')
 add_second_replicaset()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
@@ -294,10 +294,10 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.stop_loading()
+util.stop_loading()
 ---
 ...
-rebalancer_util.check_loading_result()
+util.check_loading_result()
 ---
 - true
 ...
@@ -357,7 +357,7 @@ test_run:switch('router_1')
 ---
 - true
 ...
-rebalancer_util.start_loading()
+util.start_loading()
 ---
 ...
 test_run:switch('box_4_a')
@@ -406,7 +406,7 @@ test_run:switch('router_1')
 remove_second_replicaset_first_stage()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
@@ -481,16 +481,16 @@ test_run:switch('router_1')
 remove_replicaset_first_stage()
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 fiber.sleep(0.5)
 ---
 ...
-rebalancer_util.stop_loading()
+util.stop_loading()
 ---
 ...
-rebalancer_util.check_loading_result()
+util.check_loading_result()
 ---
 - true
 ...

--- a/test/rebalancer/stress_add_remove_several_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_several_rs.test.lua
@@ -39,10 +39,10 @@ vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 
 test_run:switch('router_1')
-rebalancer_util = require('rebalancer_utils')
-util.box_router_cfg(cfg)
+util = require('rebalancer_utils')
+vshard.router.cfg(cfg)
 vshard.router.discovery_wakeup()
-rebalancer_util.start_loading()
+util.start_loading()
 
 -- At first, add one replicaset.
 
@@ -65,7 +65,7 @@ fiber.sleep(0.5)
 
 test_run:switch('router_1')
 add_replicaset()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
 
 test_run:switch('box_1_a')
@@ -106,14 +106,14 @@ fiber.sleep(0.5)
 
 test_run:switch('router_1')
 add_second_replicaset()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
 
 test_run:switch('box_1_a')
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 test_run:switch('router_1')
-rebalancer_util.stop_loading()
-rebalancer_util.check_loading_result()
+util.stop_loading()
+util.check_loading_result()
 
 test_run:switch('box_1_a')
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
@@ -133,7 +133,7 @@ check_consistency()
 -- rebalancing and remove second one.
 --
 test_run:switch('router_1')
-rebalancer_util.start_loading()
+util.start_loading()
 test_run:switch('box_4_a')
 remove_second_replicaset_first_stage()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_4_a)
@@ -148,7 +148,7 @@ vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
 fiber.sleep(0.5)
 test_run:switch('router_1')
 remove_second_replicaset_first_stage()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
 test_run:switch('box_1_a')
 remove_second_replicaset_first_stage()
@@ -173,10 +173,10 @@ vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
 fiber.sleep(0.5)
 test_run:switch('router_1')
 remove_replicaset_first_stage()
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 fiber.sleep(0.5)
-rebalancer_util.stop_loading()
-rebalancer_util.check_loading_result()
+util.stop_loading()
+util.check_loading_result()
 
 test_run:switch('box_1_a')
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}

--- a/test/router-luatest/router_test.lua
+++ b/test/router-luatest/router_test.lua
@@ -458,19 +458,40 @@ g.test_enable_disable = function(g)
     -- gh-291: router enable/disable
     --
     local router = vtest.router_new(g, 'router_1')
+    -- do not allow router's configuration to complete
+    router:exec(function()
+        _G.ivshard.router.internal.errinj.ERRINJ_CFG_DELAY = true
+    end)
     router:exec(function(cfg)
         ivtest.clear_test_cfg_options(cfg)
-        -- Do not allow router's configuration to complete
-        _G.ivshard.router.internal.errinj.ERRINJ_CFG_DELAY = true
-        rawset(_G, 'fiber_static', ifiber.create(ivshard.router.cfg, cfg))
-        rawset(_G, 'fiber_new', ifiber.create(ivshard.router.new,
-                                              'new_router', cfg))
+        rawset(_G, 'fiber_static', ifiber.new(ivshard.router.cfg, cfg))
+        rawset(_G, 'fiber_new', ifiber.new(ivshard.router.new,
+                                           'new_router', cfg))
         _G.fiber_static:set_joinable(true)
         _G.fiber_new:set_joinable(true)
+    end, {global_cfg})
+
+    local err1, err2 = router:exec(function()
+        -- emulate unconfigured box
+        local old_box_cfg = box.cfg
+        box.cfg = function(...) return old_box_cfg(...) end
+
         local routers = ivshard.router.internal.routers
         rawset(_G, 'static_router', routers._static_router)
         rawset(_G, 'new_router', routers.new_router)
-    end, {global_cfg})
+        local _, err_1 = pcall(_G.static_router.info, _G.static_router)
+        local _, err_2 = pcall(_G.new_router.info, _G.new_router)
+
+        box.cfg = old_box_cfg
+        return err_1, err_2
+    end)
+    assert_errors_equals(err1, err2, 'box seems not to be configured')
+
+    -- set box status to loading
+    router:exec(function()
+        rawset(_G, 'old_box_info', box.info)
+        box.info = {status = 'loading'}
+    end)
 
     local echo_func = function()
         return router:exec(function(timeout)
@@ -484,7 +505,15 @@ g.test_enable_disable = function(g)
         end, {vtest.wait_timeout})
     end
 
-    local err1, err2 = echo_func()
+    err1, err2 = echo_func()
+    assert_errors_equals(err1, err2, 'instance status is "loading"')
+
+    -- restore proper box configuration
+    router:exec(function()
+        box.info = _G.old_box_info
+    end)
+
+    err1, err2 = echo_func()
     assert_errors_equals(err1, err2, 'router is not configured')
 
     -- unblock router's configuration and wait until it's finished

--- a/test/router/router_2.lua
+++ b/test/router/router_2.lua
@@ -3,4 +3,4 @@ cfg = dofile('config.lua')
 cfg.listen = 3300
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')
-require('util').box_router_cfg(cfg)
+vshard.router.cfg(cfg)

--- a/test/router/router_3.lua
+++ b/test/router/router_3.lua
@@ -2,7 +2,6 @@
 fiber = require('fiber')
 cfg = dofile('config.lua')
 cfg.listen = 3300
-util = require('util')
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')
 box.cfg{listen = cfg.listen}

--- a/test/router/wrong_config.result
+++ b/test/router/wrong_config.result
@@ -28,7 +28,7 @@ _ = test_run:switch("router_3")
 cfg.bucket_count = 3000
 ---
 ...
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 ---
 ...
 vshard.router.bootstrap()
@@ -42,7 +42,7 @@ vshard.router.bootstrap()
 cfg.bucket_count = 1000
 ---
 ...
-r = util.box_router_cfg(cfg, 'gh-179')
+r = vshard.router.new('gh-179', cfg)
 ---
 ...
 while r:info().bucket.available_rw ~= 3000 do                                   \

--- a/test/router/wrong_config.test.lua
+++ b/test/router/wrong_config.test.lua
@@ -9,7 +9,7 @@ _ = test_run:cmd("start server router_3")
 _ = test_run:switch("router_3")
 
 cfg.bucket_count = 3000
-util.box_router_cfg(cfg)
+vshard.router.cfg(cfg)
 vshard.router.bootstrap()
 
 --
@@ -17,7 +17,7 @@ vshard.router.bootstrap()
 -- configured improperly.
 --
 cfg.bucket_count = 1000
-r = util.box_router_cfg(cfg, 'gh-179')
+r = vshard.router.new('gh-179', cfg)
 while r:info().bucket.available_rw ~= 3000 do                                   \
     r:discovery_wakeup()                                                        \
     fiber.sleep(0.1)                                                            \

--- a/test/storage-luatest/box_cfg_mode_test.lua
+++ b/test/storage-luatest/box_cfg_mode_test.lua
@@ -32,7 +32,7 @@ test_group.before_all(function(g)
 end)
 
 test_group.after_all(function(g)
-    g.cluster:stop()
+    g.cluster:drop()
 end)
 
 test_group.test_storage_disabled_error = function(g)
@@ -52,7 +52,9 @@ end
 -- to executing vshard.storage.cfg. So, just some basic test.
 --
 test_group.test_storage_basic = function(g)
-    t.assert(g.replica_1_a:grep_log('Box configuration was skipped'))
+    -- noreset in order to not depend on reconfiguration in previous tests.
+    t.assert(g.replica_1_a:grep_log('Box configuration was skipped',
+                                    65536, {noreset = true}))
     local bid = g.replica_1_a:exec(function(uuid)
         local bid = _G.get_first_bucket()
         local ok, err = ivshard.storage.bucket_send(bid, uuid)

--- a/vshard/router/init.lua
+++ b/vshard/router/init.lua
@@ -56,8 +56,6 @@ if not M then
         -- This counter is used to restart background fibers with
         -- new reloaded code.
         module_version = 0,
-        -- Flag whether box.info.status is acceptable.
-        is_loaded = false,
 
         ----------------------- Map-Reduce -----------------------
         -- Storage Ref ID. It must be unique for each ref request
@@ -1698,20 +1696,7 @@ end
 -- the beginning of instance's lifetime.
 --
 local function router_api_call_unsafe(func, router, ...)
-    -- box.info is quite expensive. Avoid calling it again when the instance
-    -- is finally loaded.
-    if not M.is_loaded then
-        if type(box.cfg) == 'function' then
-            local msg = 'box seems not to be configured'
-            return error(lerror.vshard(lerror.code.ROUTER_IS_DISABLED, msg))
-        end
-        local status = box.info.status
-        if status ~= 'running' then
-            local msg = ('instance status is "%s"'):format(status)
-            return error(lerror.vshard(lerror.code.ROUTER_IS_DISABLED, msg))
-        end
-        M.is_loaded = true
-    end
+    -- Router can be started on instance with unconfigured box.cfg.
     if not router.is_configured then
         local msg = 'router is not configured'
         return error(lerror.vshard(lerror.code.ROUTER_IS_DISABLED, msg))


### PR DESCRIPTION
1. https://github.com/tarantool/doc/issues/3895 should be closed after merging. 
2. https://github.com/tarantool/vshard/issues/353 should be reopened and closed as not planned.

Note, that https://github.com/tarantool/vshard/commit/a5304557e052f95541ab44953c5aa882f9f58dce intentionally wasn't reverted. I suppose, it's correct. We should not set `box.cfg.replication_timeout` during config generation. It should be done inside template, storages need this option, routers - don't. 