### PR TITLE
ci: bump test-run

### DIFF
--- a/example/router.lua
+++ b/example/router.lua
@@ -17,7 +17,6 @@ cfg = dofile('localcfg.lua')
 if arg[1] == 'discovery_disable' then
     cfg.discovery_mode = 'off'
 end
-cfg.listen = 3300
 
 -- Start the database with sharding
 vshard = require('vshard')

--- a/test/failover/router_1.lua
+++ b/test/failover/router_1.lua
@@ -13,24 +13,19 @@ local names = dofile('names.lua')
 log = require('log')
 rs_uuid = names.rs_uuid
 replica_uuid = names.replica_uuid
-local port
 zone = nil
 if name == 'router_1' then
-	port = 3333
 	zone = 1
 elseif name == 'router_2' then
-	port = 3334
 	zone = 2
 elseif name == 'router_3' then
-	port = 3335
 	zone = 3
 else
-	port = 3336
 	zone = 4
 end
 cfg.zone = zone
 
-box.cfg{listen = port}
+box.cfg{}
 
 function wait_state(state)
 	log.info(string.rep('a', 1000))

--- a/test/misc/bad_uuid_router.lua
+++ b/test/misc/bad_uuid_router.lua
@@ -5,10 +5,9 @@ require('console').listen(os.getenv('ADMIN'))
 
 -- Call a configuration provider
 cfg = require('bad_uuid_config').cfg
-cfg.listen = 3300
 
 -- Start the database with sharding
 vshard = require('vshard')
 util = require('util')
 vshard.router.cfg(cfg)
-box.cfg{listen = 3300}
+box.cfg{}

--- a/test/rebalancer/router_1.lua
+++ b/test/rebalancer/router_1.lua
@@ -4,7 +4,7 @@ vshard = require('vshard')
 os = require('os')
 fiber = require('fiber')
 
-box.cfg{listen = 3333}
+box.cfg{}
 vshard.router.cfg(cfg)
 
 require('console').listen(os.getenv('ADMIN'))

--- a/test/router/router_2.lua
+++ b/test/router/router_2.lua
@@ -1,6 +1,5 @@
 #!/usr/bin/env tarantool
 cfg = dofile('config.lua')
-cfg.listen = 3300
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')
 vshard.router.cfg(cfg)

--- a/test/router/router_3.lua
+++ b/test/router/router_3.lua
@@ -1,7 +1,6 @@
 #!/usr/bin/env tarantool
 fiber = require('fiber')
 cfg = dofile('config.lua')
-cfg.listen = 3300
 require('console').listen(os.getenv('ADMIN'))
 vshard = require('vshard')
-box.cfg{listen = cfg.listen}
+box.cfg{}


### PR DESCRIPTION
In the near future we plan to test Tarantool installed from a DEB/RPM package. Since 3.0.0-alpha1 release Tarantool packages don't have the tarantoolctl utility inside.

tarantoolctl was ebmed to the test-run project inself. The submodule has been updated to the latest version.