### PR TITLE
replicaset: validate name in replicaset_locate_master

### DIFF
--- a/test/router/router.result
+++ b/test/router/router.result
@@ -1525,7 +1525,8 @@ table.sort(error_messages)
 ...
 error_messages
 ---
-- - Use replica:detach_conn(...) instead of replica.detach_conn(...)
+- - Use replica:check_is_connected(...) instead of replica.check_is_connected(...)
+  - Use replica:detach_conn(...) instead of replica.detach_conn(...)
   - Use replica:is_connected(...) instead of replica.is_connected(...)
   - Use replica:safe_uri(...) instead of replica.safe_uri(...)
 ...


### PR DESCRIPTION
Currently, the name validation is not used, when locate_master() is called. It makes an explicit call via the connection to obtain a future object in order to figure out, whether the node is a master.

We should not make any calls to a replica until the time, we definitely know, that its name and uuid was validated. Let's use replica_call instead of conn.call.

Follow-up #426

NO_DOC=bugfix