### PR TITLE
storage: fix schema log message

### DIFF
--- a/test/unit-luatest/storage_exports_test.lua
+++ b/test/unit-luatest/storage_exports_test.lua
@@ -135,3 +135,15 @@ test_group.test_deploy_privs = function(g)
         box.schema.role.drop('two')
     end)
 end
+
+test_group.test_core_version = function(g)
+    g.server:exec(function()
+        local exports = _G.ivexports.log[#_G.ivexports.log]
+        exports = _G.ivexports.compile(exports)
+
+        local version = _TARANTOOL
+        local pos = version:find('-g')
+        version = version:sub(1, pos - 1)
+        ilt.assert_equals(exports.core_version, version)
+    end)
+end

--- a/test/unit-luatest/version_test.lua
+++ b/test/unit-luatest/version_test.lua
@@ -3,6 +3,23 @@ local lversion = require('vshard.version')
 
 local g = t.group('version')
 
+local function assert_version_str_equals(actual, expected)
+    -- Remove commit hash, if it exists. It's not saved in version.
+    local hash_pos = expected:find('-g')
+    if hash_pos then
+        expected = expected:sub(1, hash_pos - 1)
+    end
+    -- Remove trailing dash.
+    if expected:sub(-1) == '-' then
+        expected = expected:sub(1, -2)
+    end
+    -- Add 0 number of commits to expected.
+    if actual:sub(-2) == '-0' and not expected:find('-0') then
+        expected = expected .. '-0'
+    end
+    t.assert_equals(actual, expected)
+end
+
 g.test_order = function()
     -- Example of a full version: 2.10.0-beta2-86-gc9981a567.
     local versions = {
@@ -215,6 +232,7 @@ g.test_order = function()
         t.assert(not (ver > v.ver), ('versions not >, %d'):format(i))
         t.assert(ver <= v.ver, ('versions <=, %d'):format(i))
         t.assert(ver >= v.ver, ('versions <=, %d'):format(i))
+        assert_version_str_equals(tostring(ver), v.str)
         if i > 1 then
             local prev = versions[i - 1].ver
             t.assert(prev < ver, ('versions <, %d'):format(i))

--- a/vshard/storage/exports.lua
+++ b/vshard/storage/exports.lua
@@ -43,7 +43,7 @@ local function exports_compile(exports)
     end
     return {
         vshard_version = exports.version,
-        core_version = table.concat(lvutil.core_version, '.'),
+        core_version = tostring(lvutil.core_version),
         funcs = compiled_funcs,
     }
 end

--- a/vshard/version.lua
+++ b/vshard/version.lua
@@ -75,6 +75,17 @@ local version_mt = {
     __le = function(l, r)
         return version_cmp(l, r) <= 0
     end,
+    __tostring = function(v)
+        local str = v.id_major .. '.' .. v.id_middle .. '.' .. v.id_minor
+        if v.rel_type then
+            str = str .. '-' .. v.rel_type
+            if v.rel_num ~= 0 then
+                str = str .. v.rel_num
+            end
+        end
+        str = str .. '-' .. v.id_commit
+        return str
+    end,
 }
 
 local function version_new(id_major, id_middle, id_minor, rel_type, rel_num,


### PR DESCRIPTION
storage: fix schema log message

exports_deply_funcs() used to log the core version as nil. The problem
is the fact, that table.concat was used for core version string, so the
complied exports always had nil instead of core_version.

table.concat doesn't work with non-array tables, as they have no defined
order. Let's explicitly define __tostring function for version and use
it in order to log core version.

Closes https://github.com/tarantool/vshard/issues/465

NO_DOC=bugfix