### PR TITLE
storage: fix hot reload with named identification

### DIFF
--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -4036,7 +4036,8 @@ if not rawget(_G, MODULE_INTERNALS) then
 else
     reload_evolution.upgrade(M)
     if M.current_cfg then
-        storage_cfg(M.current_cfg, M.this_replica.uuid, true)
+        storage_cfg(M.current_cfg, M.this_replica.id or M.this_replica.uuid,
+                    true)
     end
     M.module_version = M.module_version + 1
     -- Background fibers could sleep waiting for bucket changes.


### PR DESCRIPTION
Currently hot reload failes, when named identification is used. It is cause by the fact, that we still pass uuid in storage.cfg during reload.

Let's pass id instead of UUID. It's either uuid or name, depeding on identification_mode. If reload is done from the old version, where no replica.id exists, we fall back to replica.uuid.

Closes #464

NO_DOC=bugfix