### PR TITLE
test: fix flaky failover/failover.test.lua

### DIFF
--- a/test/failover/failover.result
+++ b/test/failover/failover.result
@@ -491,6 +491,11 @@ while rs.master ~= rs.replica do fiber.sleep(0.01) end
 future = nil
 ---
 ...
+-- Create strong reference to prevent Lua GC from closing the
+-- connection. Waiting for tarantool/tarantool#9629 to be fixed.
+conn = rs.master.conn
+---
+...
 while not future do fiber.sleep(0.01) future = vshard.router.callrw(31, 'echo', {t}, {is_async = true}) end
 ---
 ...

--- a/test/failover/failover.test.lua
+++ b/test/failover/failover.test.lua
@@ -181,6 +181,9 @@ t = string.rep('a', 1024 * 1024 * 500)
 rs = vshard.router.route(31)
 while rs.master ~= rs.replica do fiber.sleep(0.01) end
 future = nil
+-- Create strong reference to prevent Lua GC from closing the
+-- connection. Waiting for tarantool/tarantool#9629 to be fixed.
+conn = rs.master.conn
 while not future do fiber.sleep(0.01) future = vshard.router.callrw(31, 'echo', {t}, {is_async = true}) end
 vshard.router.static.failover_fiber:wakeup()
 res, err = future:wait_result(5)


### PR DESCRIPTION
Router pings replicas and if they cannot respond in
failover_ping_timeout, it detaches connection from this replica.
The test checks, that connection is not closed, when long response is
done, even if failover_ping_timeout is small.

However, when the connection is detached, it can be garbage collected,
which leads to 'Connection closed' error. Let's stop Lua GC for the
connection by creating reference to it.

Related to https://github.com/tarantool/tarantool/issues/9629

NO_DOC=test