### PR TITLE
test: update `async_no_yield` test from `vconnect` test group

### DIFF
--- a/test/replicaset-luatest/vconnect_test.lua
+++ b/test/replicaset-luatest/vconnect_test.lua
@@ -176,8 +176,14 @@ test_group.test_async_no_yield = function(g)
     local csw1 = fiber.self():csw()
     local ret, err = rs:callrw('get_uuid', {}, opts)
     local csw2 = fiber.self():csw()
-    -- Waiting for #456 to be fixed.
-    t.assert_equals(csw2, csw1 + 1)
+    if vutil.version_is_at_least(2, 11, 0, nil, 0, 0) then
+        -- Temporarily disabled until #456 is fixed.
+        -- t.assert_equals(csw2, csw1)
+        t.assert(true)
+    else
+        -- Due to tarantool/tarantool#9489 bug.
+        t.assert_equals(csw2, csw1 + 1)
+    end
     t.assert_str_contains(err.name, 'VHANDSHAKE_NOT_COMPLETE')
     t.assert_equals(ret, nil)
     t.assert_not_equals(rs.master.conn.state, 'closed')


### PR DESCRIPTION
This patch brings an update to the test to reflect the correct behavior after tarantool/tarantool#9489 is fixed. The test against correct behavior is temporarily disabled until tarantol/tarantool#9803 is merged.

This patch needs to be merged before https://github.com/tarantool/tarantool/pull/9803.

Part of #456