### PR TITLE
failover: add failover priority replica option

### DIFF
--- a/test/failover-luatest/failover_test.lua
+++ b/test/failover-luatest/failover_test.lua
@@ -1,0 +1,59 @@
+local t = require('luatest')
+local vtest = require('test.luatest_helpers.vtest')
+
+local g = t.group('failover')
+
+g.after_all(function(g)
+    g.cluster:stop()
+end)
+
+
+g.test_failover_priorities = function(g)
+    local cfg = {
+        sharding = {
+            replicaset_1 = {
+                replicas = {
+                    replica_1 = { master = true, failover_priority = 1 },
+                    replica_2 = { failover_priority = 5 },
+                    replica_3 = { failover_priority = 3 },
+                    replica_4 = { failover_priority = 2 },
+                    replica_5 = { failover_priority = 4 },
+                },
+            },
+        }
+    }
+
+    local global_cfg = vtest.config_new(cfg)
+
+    vtest.cluster_new(g, global_cfg)
+    g.router = vtest.router_new(g, 'router', global_cfg)
+    local res, err = g.router:exec(function()
+        return ivshard.router.bootstrap({timeout = iwait_timeout})
+    end)
+    t.assert(res and not err, 'bootstrap buckets')
+
+    vtest.cluster_wait_vclock_all(g)
+
+    local function check_current_replica(storage)
+        g.router:exec(function(rs_uuid, instance_uuid)
+            local router = ivshard.router.internal.static_router
+            local rs = router.replicasets[rs_uuid]
+            local new_master = rs.replicas[instance_uuid]
+            ilt.helpers.retrying({timeout = 10}, function()
+                if rs.replica == new_master then
+                    return
+                end
+                error('Checking new replica')
+            end)
+        end, {storage:replicaset_uuid(), storage:instance_uuid()})
+    end
+
+    g.replica_1:stop()
+    check_current_replica(g.replica_4)
+
+    g.replica_4:stop()
+    check_current_replica(g.replica_3)
+
+    g.replica_3:stop()
+    check_current_replica(g.replica_5)
+end

--- a/test/failover-luatest/suite.ini
+++ b/test/failover-luatest/suite.ini
@@ -1,0 +1,5 @@
+[default]
+core = luatest
+description = Failover test
+is_parallel = True
+release_disabled =

--- a/test/unit/config.result
+++ b/test/unit/config.result
@@ -463,9 +463,9 @@ lcfg.check(cfg)['sharding']
     weight: 100000
     replicas:
       replica_uuid:
+        name: storage
         master: true
         uri: 127.0.0.1
-        name: storage
 ...
 replica.uri = 'user:password@localhost'
 ---
@@ -476,9 +476,9 @@ lcfg.check(cfg)['sharding']
     weight: 100000
     replicas:
       replica_uuid:
+        name: storage
         master: true
         uri: user:password@localhost
-        name: storage
 ...
 replica.url = old_uri
 ---

--- a/vshard/cfg.lua
+++ b/vshard/cfg.lua
@@ -230,6 +230,9 @@ local replica_template = {
         name = 'UUID',
         is_optional = true,
     },
+    failover_priority = {
+        type = 'number', name = "Failover priority", is_optional = true,
+    },
 }
 
 local function check_replicas(replicas, ctx)

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -1431,6 +1431,7 @@ local function buildall(sharding_cfg)
                 net_sequential_ok = 0, net_sequential_fail = 0,
                 down_ts = curr_ts, backoff_ts = nil, backoff_err = nil,
                 id = replica_id,
+                failover_priority = replica.failover_priority or math.huge
             }, replica_mt)
             new_replicaset.replicas[replica_id] = new_replica
             if replica.master then
@@ -1457,6 +1458,9 @@ local function buildall(sharding_cfg)
 
         -- Return true, if r1 has priority over r2.
         local function replica_cmp_weight(r1, r2)
+            if r1.failover_priority ~= r2.failover_priority then
+                return r1.failover_priority < r2.failover_priority
+            end
             -- Master has priority over replicas with the same
             -- weight.
             if r1.weight == r2.weight then


### PR DESCRIPTION
Add the `failover_priority` config option in the] `sharding.<replicaset_id>.replicas.<replica_id>` section.

Using the option you may specify the order failover will connect to the replicas. The lower the value, the higher the priority of the replica.

