### PR TITLE
test: ignore zero lsn when waiting for vclock in router2 test

### DIFF
--- a/test/router/router2.result
+++ b/test/router/router2.result
@@ -394,7 +394,8 @@ echo_count = 0
 box.cfg{replication = old_replication}
  | ---
  | ...
-test_run:wait_vclock('storage_2_b', test_run:get_vclock('storage_1_a'))
+test_run:wait_vclock('storage_2_b',                                             \
+    test_run:get_vclock('storage_1_a', {ignore_zero = true}))
  | ---
  | ...
 
@@ -425,7 +426,8 @@ assert(echo_count == 0)
 box.schema.user.grant('storage', 'execute', 'function', 'vshard.storage.call')
  | ---
  | ...
-test_run:wait_vclock('storage_2_b', test_run:get_vclock('storage_1_a'))
+test_run:wait_vclock('storage_2_b',                                             \
+    test_run:get_vclock('storage_1_a', {ignore_zero = true}))
  | ---
  | ...
 

--- a/test/router/router2.test.lua
+++ b/test/router/router2.test.lua
@@ -157,7 +157,8 @@ assert(echo_count == 1)
 echo_count = 0
 -- Restore the replication so the replica gets the _func change from master.
 box.cfg{replication = old_replication}
-test_run:wait_vclock('storage_2_b', test_run:get_vclock('storage_1_a'))
+test_run:wait_vclock('storage_2_b',                                             \
+    test_run:get_vclock('storage_1_a', {ignore_zero = true}))
 
 test_run:switch('router_1')
 ok, err = vshard.router.callro(1, 'echo', {100}, long_timeout)
@@ -167,7 +168,8 @@ assert(err.error.code == box.error.ACCESS_DENIED)
 test_run:switch('storage_2_a')
 assert(echo_count == 0)
 box.schema.user.grant('storage', 'execute', 'function', 'vshard.storage.call')
-test_run:wait_vclock('storage_2_b', test_run:get_vclock('storage_1_a'))
+test_run:wait_vclock('storage_2_b',                                             \
+    test_run:get_vclock('storage_1_a', {ignore_zero = true}))
 
 --
 -- No vshard function = backoff.


### PR DESCRIPTION
In test `router/router2` we get vclock from one instance and wait for this vclock on another one. The problem is we get vclock with local lsn which is independent on each instance - the commit fixes this mistake.