### PR TITLE
ci: bump Ubuntu version in workflows

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -29,7 +29,9 @@ jobs:
       matrix:
         tarantool:
           - '1.10'
-          - '2.10'
+          - '2.11'
+          - '3.2'
+          - '3.3'
           - 'release-master'
 
     env:

--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -29,15 +29,13 @@ jobs:
       matrix:
         tarantool:
           - '1.10'
-          - '2.7'
-          - '2.8'
           - '2.10'
           - 'release-master'
 
     env:
       TNT_RELEASE_PATH: /home/runner/tnt-release
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
         if: startsWith(matrix.tarantool, 'release') != true

--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Install tarantool ${{ matrix.tarantool }}
         if: startsWith(matrix.tarantool, 'release') != true
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     # https://github.com/Dart-Code/Dart-Code/pull/2375
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
   checkpatch:
     if: github.event_name == 'pull_request'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '2.10'
 

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       artifact_name:
         description: 'The name of the tarantool build artifact'
-        default: ubuntu-focal
+        default: ubuntu-jammy
         required: false
         type: string
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Clone the vshard module'
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit bumps the Ubuntu distro version up to 24.04 (noble) in all existing workflows, since the Ubuntu 20.04 (focal) image support will be dropped today in the GitHub actions.

See also: actions/runner-images#11101
Closes tarantool/vshard#520

NO_DOC=ci
NO_TEST=ci