### PR TITLE
build: bump cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(ExternalProject)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(POLICY CMP0037)
-    cmake_policy(SET CMP0037 OLD)
-endif(POLICY CMP0037)
-
 add_custom_target(test
     COMMAND ${PROJECT_SOURCE_DIR}/test/test-run.py -j -1
         --builddir=${PROJECT_BINARY_DIR}


### PR DESCRIPTION
New cmake 4.0.0 removed compatibility with all version prior to 3.5

NO_DOC=build
NO_TEST=build