### PR TITLE
replicaset: fix read-only request not fallback to master

### DIFF
--- a/.github/workflows/cartridge_integration.yml
+++ b/.github/workflows/cartridge_integration.yml
@@ -1,0 +1,130 @@
+name: cartridge_integration
+
+env:
+  # Skip building frontend in tt rocks make
+  CMAKE_DUMMY_WEBUI: true
+  # Prerequisite for some etcd-related tests
+  ETCD_PATH: etcd-v2.3.8/etcd
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the tarantool build artifact
+        required: true
+        type: string
+      tarantool_version:
+        description: Version for the Tarantool binary
+        required: false
+        default: '2.11'
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - ${{ inputs.tarantool_version }}
+        etcd: ['v2.3.8']
+        metrics: ['']
+
+    steps:
+      - name: Check out the module
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/cartridge
+
+      - name: Download the vshard build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.0'
+
+      - name: Install setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+
+      - uses: tarantool/setup-tarantool@v3
+        with:
+          tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Set up etcd
+        uses: tarantool/actions/setup-etcd@master
+        with:
+          version: '${{ matrix.etcd }}'
+          install-prefix: etcd-${{ matrix.etcd }}
+
+      - run: echo "ETCD_PATH=etcd-${{ matrix.etcd }}/etcd" >> $GITHUB_ENV
+
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          sudo apt install -y tt
+          tt version
+
+      # Setup luatest
+      - name: Cache rocks
+        uses: actions/cache@v4
+        id: cache-rocks
+        with:
+          path: .rocks/
+          key: test-rocks-${{ hashFiles('*.rockspec') }}-05
+      -
+        run: tt rocks install luatest 1.0.1
+        if: steps.cache-rocks.outputs.cache-hit != 'true'
+
+      # Setup pytest
+      - name: Cache pytest
+        uses: actions/cache@v4
+        id: cache-pytest
+        with:
+          path: ./pytest-venv
+          key: test-venv-${{ hashFiles('test/integration/requirements.txt') }}-05
+
+      - name: Setup pytest
+        run: |
+          python -m venv ./pytest-venv && . ./pytest-venv/bin/activate
+          pip install --upgrade pip setuptools
+          pip install "cython<3.0.0" wheel
+          pip install -r test/integration/requirements.txt
+        if: steps.cache-pytest.outputs.cache-hit != 'true'
+
+      # Setup optional rocks
+      - name: Install metrics
+        if: matrix.metrics != ''
+        run: tt rocks install metrics ${{ matrix.metrics }}
+
+      - run: tt rocks make
+
+      # Install vshard from the rock.
+      - name: Install vshard
+        run: |
+          tt rocks remove --force vshard
+          tt rocks install ./vshard*.all.rock
+
+      # Stop Mono server. This server starts and listens to 8084 port that is
+      # used for tests.
+      - name: 'Stop Mono server'
+        run: sudo kill -9 $(sudo lsof -t -i tcp:8084) || true
+
+      - uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 30
+          command: |
+            .rocks/bin/luatest -v --fail-fast
+
+      - name: Run pytest -v
+        run: |
+          . ./pytest-venv/bin/activate
+          pytest -v
+
+      # Cleanup cached paths
+      - run: tt rocks remove cartridge

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,51 @@
+name: integration
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+
+env:
+  ROCK_NAME: vshard
+
+jobs:
+  vshard:
+    runs-on: ubuntu-22.04
+    if: |
+      github.event_name == 'pull_request' &&
+      (contains(join(github.event.pull_request.labels.*.name, ','), 'full-ci') ||
+       contains(join(github.event.pull_request.labels.*.name, ','), 'integration-ci'))
+    outputs:
+      sha: ${{ steps.get_sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Get the commit SHA'
+        id: get_sha
+        run: echo "sha=$(git log -1 --format='%H')" >> $GITHUB_OUTPUT
+      - name: Setup tarantool
+        uses: tarantool/setup-tarantool@v3
+        with:
+          tarantool-version: '2.11'
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/3/installer.sh | bash
+          sudo apt-get -y install tt
+      - name: Create test rock
+        run: |
+          tt rocks make ${{ env.ROCK_NAME }}-scm-1.rockspec
+          tt rocks pack ${{ env.ROCK_NAME }} scm-1
+      - name: Upload test rock
+        uses: actions/upload-artifact@v4
+        with:
+          name: vshard-${{ steps.get_sha.outputs.sha }}
+          retention-days: 21
+          path: |
+            ${{ env.ROCK_NAME }}-scm-1.all.rock
+
+  cartridge:
+    needs: vshard
+    uses: ./.github/workflows/cartridge_integration.yml
+    with:
+      artifact_name: vshard-${{ needs.vshard.outputs.sha }}
+      tarantool_version: '2.11'

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -934,7 +934,7 @@ local function replicaset_template_multicallro(prefer_replica, balance)
                     return nil, timeout
                 end
                 replica_connect(replica)
-                if replica.backoff_ts then
+                if not replica_check_backoff(replica, now) then
                     return nil, lerror.vshard(
                         lerror.code.REPLICASET_IN_BACKOFF, replicaset.id,
                         replica.backoff_err)


### PR DESCRIPTION
The commit d017a9ed18767 ("replicaset: speed up the read-only calls") has broken the fallback to master in read-only calls if master was in backoff. Previoulsy, we checked the backoff and dropped it right during calls, but after that commit only failover service started to do that, which caused request failure even if backoff interval already passed, because only on failover wakeup the instance could be restored.

This should not work like that and in case of fallback to master in read-only calls we should explicitly check and drop backoff, if it's possible, so that request can pass.

I also had an idea to restore the `health_status` of the replica, if `replication_status` is `GREEN` and drop backoff right after every successful call, but we should not do that, since a lot of services use replicaset:call internally, when they don't want to take refs for buckets and the success of such call doesn't mean, that vshard is already configured and instance can be used for read-only calls. So, I rejected that idea.

Closes #581

NO_DOC=bugfix