### PR TITLE
storage: fix old master not being able to find a new master

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -1139,7 +1139,7 @@ end
 local function replicaset_update_master(replicaset, old_master_id, candidate_id)
     local is_auto = replicaset.is_master_auto
     local replicaset_id = replicaset.id
-    if old_master_id == candidate_id then
+    if old_master_id and old_master_id == candidate_id then
         -- It should not happen ever, but be ready to everything.
         log.warn('Replica %s in replicaset %s reports self as both master '..
                  'and not master', old_master_id, replicaset_id)
@@ -1155,9 +1155,16 @@ local function replicaset_update_master(replicaset, old_master_id, candidate_id)
             return true
         end
         replicaset.master = candidate
-        log.info('Replica %s becomes a master as reported by %s for '..
-                 'replicaset %s', candidate_id, old_master_id,
-                 replicaset_id)
+        local msg
+        if old_master_id then
+            msg = string.format('Replica %s becomes a master as reported ' ..
+                'by %s for replicaset %s', candidate_id, old_master_id,
+                replicaset_id)
+        else
+            msg = string.format('Replica %s becomes a master for replicaset %s',
+                candidate_id, replicaset_id)
+        end
+        log.info(msg)
         return true
     end
     local master_id = master.id

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -3404,6 +3404,10 @@ end
 local function master_on_disable()
     log.info("Stepping down from the master role")
     M.is_master = false
+    local rs = M.this_replicaset
+    if rs.master ~= nil then
+        rs:update_master(rs.master.id, nil)
+    end
     M._on_master_disable:run()
     master_role_update()
     rebalancer_role_update()
@@ -3412,6 +3416,11 @@ end
 local function master_on_enable()
     log.info("Stepping up into the master role")
     M.is_master = true
+    local rs = M.this_replicaset
+    if rs.master ~= M.this_replica then
+        local old_master_id = rs.master and rs.master.id
+        M.this_replicaset:update_master(old_master_id, M.this_replica.id)
+    end
     M._on_master_enable:run()
     master_role_update()
     rebalancer_role_update()


### PR DESCRIPTION
This bug is reproduced only with auto_master feature enabled. It manifests itself in inability for an old master to find a new one, when switch happens.

M.this_replicaset.master and M.is_master becomes incosistent and old master starts to respond, that it's not a master, but the only master it knows is itself. This causes the spam of logs on the new master, services there stop. Old master doesn't respond correctly to router's ping, while being in this state.

In the absence of tarantool/vshard#605 bug this state ends in 40 seconds (REPLICA_NOACTIVITY_TIMEOUT + MASTER_SEARCH_IDLE_INTERVAL * 2). However, since connection manager cannot GC the stale connect and consequently master search service cannot drop the master, it prolongs to infinity.

Speaking of implementation, we don't explicitly change the `M.current_replicaset.master` variable in order to preserve encapsulation of that variable, `replicaset:update_master` is used instead.

Closes #604

NO_DOC=bugfix