### PR TITLE
replicaset: fix connection not GCed after rebind

### DIFF
--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -1098,6 +1098,7 @@ local function rebind_replicasets(replicasets, old_replicasets)
                     local conn = old_replica.conn
                     old_replica.conn = nil
                     replica.conn = conn
+                    replica.activity_ts = old_replica.activity_ts
                     if conn then
                         conn.replica = replica
                     end


### PR DESCRIPTION
The connection is rebound in order not to reconnect to instance on every reconfiguration. However, if connection is rebinded, it cannot be garbage collected until the `activity_ts` variable is bumped (e.g. during some call to replica). However, e.g. on replicas this variable never bumped, so if replica was a master and stopped being it, `activity_ts` variable won't be bumped at all and consequently, the connection won't be garbage collected ever.

Closes #605

NO_DOC=bugfix