### PR TITLE
storage: preserve original error on function fail

### DIFF
--- a/test/storage-luatest/storage_1_test.lua
+++ b/test/storage-luatest/storage_1_test.lua
@@ -674,3 +674,28 @@ test_group.test_info_disable_consistency = function(g)
         ilt.assert(res.is_enabled)
     end, {global_cfg})
 end
+
+local function test_error_msg_is_preserved_template(g, add_to_schema)
+    g.replica_1_a:exec(function(add_to_schema)
+        rawset(_G, 'test_fail', function()
+            box.begin()
+            error('test_error')
+        end)
+        if add_to_schema then
+            box.schema.func.create('test_fail')
+        end
+        local status, err = ivshard.storage.call(1, 'read', 'test_fail', {})
+        ilt.assert_not(status)
+        ilt.assert_str_contains(err.message, 'test_error')
+        ilt.assert_not_str_contains(err.message, 'Transaction is active')
+        rawset(_G, 'test_fail', nil)
+        if add_to_schema then
+            box.schema.func.drop('test_fail')
+        end
+    end, {add_to_schema})
+end
+
+test_group.test_error_msg_is_preserved = function(g)
+    test_error_msg_is_preserved_template(g, false)
+    test_error_msg_is_preserved_template(g, true)
+end

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -261,6 +261,20 @@ else
 end
 
 --
+-- If the function is called directly, fails, and leaves an uncommitted
+-- transaction, the original error is replaced by the "Transaction is active"
+-- error. We manually check if the function returned an error. If so, we
+-- rollback the transaction to reveal the original error.
+--
+local function handle_results(status, ...)
+    if not status then
+        box.rollback()
+        return status, box.error.new(box.error.PROC_LUA, (...))
+    end
+    return status, ...
+end
+
+--
 -- Invoke a function on this instance. Arguments are unpacked into the function
 -- as arguments.
 -- The function returns pcall() as is, because is used from places where
@@ -284,7 +298,7 @@ local_call = function(func_name, args)
     if not func then
         return pcall(netbox_self_call, netbox_self, func_name, args)
     end
-    return pcall(func.call, func, args)
+    return handle_results(pcall(func.call, func, args))
 end
 
 end


### PR DESCRIPTION
For older Tarantool versions vshard uses func.call to execute functions.

If such a function raises an error during an uncommitted transaction, 'Transaction is active...' error is going to be raised, which will mask the original error.

This patch fixes that bug by checking the function call result. If the function returns an error and a transaction is still active, vshard now explicitly rolls back the transaction.

Fixes #614

NO_DOC=bugfix