### PR TITLE
replicaset: log replica in connection triggers

### DIFF
--- a/test/router/router.result
+++ b/test/router/router.result
@@ -47,9 +47,9 @@ util = require('util')
 ---
 ...
 -- gh-24: log all connnect/disconnect events.
-test_run:grep_log('router_1', 'connected to ')
+test_run:grep_log('router_1', 'connected to replica')
 ---
-- 'connected to '
+- connected to replica
 ...
 rs1 = vshard.router.static.replicasets[util.replicasets[1]]
 ---

--- a/test/router/router.test.lua
+++ b/test/router/router.test.lua
@@ -19,7 +19,7 @@ cfg.sharding ~= nil
 util = require('util')
 
 -- gh-24: log all connnect/disconnect events.
-test_run:grep_log('router_1', 'connected to ')
+test_run:grep_log('router_1', 'connected to replica')
 rs1 = vshard.router.static.replicasets[util.replicasets[1]]
 rs2 = vshard.router.static.replicasets[util.replicasets[2]]
 fiber = require('fiber')

--- a/vshard/replicaset.lua
+++ b/vshard/replicaset.lua
@@ -270,8 +270,8 @@ end
 -- on_connect() trigger for net.box
 --
 local function netbox_on_connect(conn)
-    log.info("connected to %s:%s", conn.host, conn.port)
     local replica = conn.replica
+    log.info("connected to %s", replica)
     assert(replica ~= nil)
     -- If a replica's connection has revived, then unset
     -- replica.down_ts - it is not down anymore.
@@ -303,11 +303,12 @@ end
 -- on_disconnect() trigger for net.box
 --
 local function netbox_on_disconnect(conn)
-    log.info("disconnected from %s:%s", conn.host, conn.port)
-    assert(conn.replica)
+    local replica = conn.replica
+    log.info("disconnected from %s", replica)
+    assert(replica ~= nil)
     -- Replica is down - remember this time to decrease replica
     -- priority after FAILOVER_DOWN_TIMEOUT seconds.
-    conn.replica.down_ts = fiber_clock()
+    replica.down_ts = fiber_clock()
     -- Future object must be removed from the connection, otherwise
     -- the connection cannot be garbage collected (gh-517).
     -- Moreover, future object must be updated. Old result is irrelevant.


### PR DESCRIPTION
Before this patch, only the host and port were written to logs on connection or disconnection. However, it was very difficult to figure out to which replica we connected/disconnected, which made debugging the logs frustrating. Let's instead log the full replica object, which includes the replica id and its URI.