### PR TITLE
ci: fixup reusable_testing workflow

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -37,5 +37,14 @@ jobs:
       - name: 'Install test requirements'
         run: pip3 install --user -r test-run/requirements.txt
 
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          sudo apt install -y tt
+          tt version
+
+      - name: Setup luatest
+        run: tt rocks install luatest
+
       - run: cmake .
       - run: make test-force


### PR DESCRIPTION
This is the follow-up for the ed801821e36e43b2ef57360323dfed13985135dc ("ci: bump test-run"). Since this version of the test-run the reusable_testing workflow is failing due to the absence of the luatest.

This patch makes the workflow in touch with the fast_testing.

Needed for tarantool/tarantool#11220

NO_DOC=ci
NO_TEST=ci

---

The another one surprise -- missing dependencies in this workflow.
See [this log](https://github.com/tarantool/tarantool/actions/runs/21285544345/job/61266687987?pr=11220#step:7:6).
