### PR TITLE
test: fix too long server names

### DIFF
--- a/test/replicaset-luatest/replicaset_3_test.lua
+++ b/test/replicaset-luatest/replicaset_3_test.lua
@@ -618,7 +618,7 @@ test_group.test_storage_info_fail_while_replica_has_master_name = function(g)
     t.run_only_if(vutil.feature.persistent_names)
 
     local replica = server:new({
-        alias = 'non_config_replica_with_master_name',
+        alias = 'non_cfg_replica_master_name',
         box_cfg = {
             replication = {
                 g.replica_1_a.net_box_uri,

--- a/test/storage-luatest/persistent_names_1_1_test.lua
+++ b/test/storage-luatest/persistent_names_1_1_test.lua
@@ -144,7 +144,7 @@ test_group.test_alerts_for_named_replica = function(g)
     t.run_only_if(vutil.feature.persistent_names)
 
     local named_replica = server:new({
-        alias = 'named_replica_with_name_identification',
+        alias = 'named_replica',
         box_cfg = {
             replication = g.replica_1_a.net_box_uri,
             instance_name = 'named_replica'


### PR DESCRIPTION
<replicaset-luatest/replicaset_3_test.lua> and
<storage-luatest/persistent_names_1_1_test.lua> have too long server names to be started in the CI workflow reusable_testing.

This patch shortens these names.

Needed for tarantool/tarantool#11220

NO_DOC=test

---

See [this CI log](https://github.com/tarantool/tarantool/actions/runs/21357802982/job/61470272587#step:9:109) for details.