### PR TITLE
test: fix flakiness of rebalancer stress tests

### DIFF
--- a/test/rebalancer/bucket_ref.result
+++ b/test/rebalancer/bucket_ref.result
@@ -38,7 +38,7 @@ _ = test_run:switch('box_1_a')
 vshard.storage.rebalancer_disable()
 ---
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -48,7 +48,7 @@ _ = test_run:switch('box_2_a')
 vshard.storage.rebalancer_disable()
 ---
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(101, 50)
 ---
 - true
 ...

--- a/test/rebalancer/bucket_ref.test.lua
+++ b/test/rebalancer/bucket_ref.test.lua
@@ -16,10 +16,10 @@ util.push_rs_filters(test_run)
 --
 _ = test_run:switch('box_1_a')
 vshard.storage.rebalancer_disable()
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 _ = test_run:switch('box_2_a')
 vshard.storage.rebalancer_disable()
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(101, 50)
 _ = test_run:switch('box_1_a')
 
 vshard.storage.bucket_refro(1)

--- a/test/rebalancer/config.lua
+++ b/test/rebalancer/config.lua
@@ -75,7 +75,7 @@ end
 
 return {
     -- Use small number of buckets to speedup tests.
-    bucket_count = 200,
+    bucket_count = 100,
     sharding = sharding,
     rebalancer_disbalance_threshold = 0.01,
     rebalancer_max_sending = 5,

--- a/test/rebalancer/errinj.result
+++ b/test/rebalancer/errinj.result
@@ -59,7 +59,7 @@ wait_rebalancer_state('Total active bucket count is not equal to total', test_ru
 vshard.storage.rebalancer_disable()
 ---
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -70,7 +70,7 @@ test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(101, 50)
 ---
 - true
 ...
@@ -158,7 +158,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE}
 ---
-- 67
+- 34
 ...
 test_run:switch('box_2_a')
 ---
@@ -166,7 +166,7 @@ test_run:switch('box_2_a')
 ...
 _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE}
 ---
-- 133
+- 66
 ...
 --
 -- Test that it is possible to send multiple bucket at the same

--- a/test/rebalancer/errinj.test.lua
+++ b/test/rebalancer/errinj.test.lua
@@ -32,11 +32,11 @@ _bucket = box.space._bucket
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 wait_rebalancer_state('Total active bucket count is not equal to total', test_run)
 vshard.storage.rebalancer_disable()
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 
 test_run:switch('box_2_a')
 _bucket = box.space._bucket
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(101, 50)
 vshard.storage.internal.errinj.ERRINJ_LONG_RECEIVE = true
 
 test_run:switch('box_1_a')

--- a/test/rebalancer/parallel.result
+++ b/test/rebalancer/parallel.result
@@ -77,7 +77,7 @@ test_run:switch('box_1_a')
  | ---
  | - true
  | ...
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
  | ---
  | - true
  | ...

--- a/test/rebalancer/parallel.test.lua
+++ b/test/rebalancer/parallel.test.lua
@@ -35,7 +35,7 @@ util.map_evals(test_run, {REPLICASET_1, REPLICASET_2, REPLICASET_3, REPLICASET_4
 ]])
 
 test_run:switch('box_1_a')
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 t1 = fiber.time()
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 t2 = fiber.time()

--- a/test/rebalancer/rebalancer.result
+++ b/test/rebalancer/rebalancer.result
@@ -74,7 +74,7 @@ wait_rebalancer_state('Total active bucket count is not equal to total', test_ru
 ---
 ...
 --
--- Fill the cluster with buckets saving the balance 100 buckets
+-- Fill the cluster with buckets saving the balance 50 buckets
 -- per replicaset.
 --
 vshard.storage.rebalancer_disable()
@@ -86,7 +86,7 @@ cfg.rebalancer_max_receiving = 10
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 ---
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -97,7 +97,7 @@ test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 ---
 - true
 ...
@@ -122,7 +122,7 @@ test_run:switch('box_2_a')
 ---
 - true
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -166,7 +166,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 test_run:switch('box_2_a')
 ---
@@ -174,7 +174,7 @@ test_run:switch('box_2_a')
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 --
 -- Send buckets again, but now from a replicaset with no
@@ -196,7 +196,7 @@ vshard.storage.rebalancer_disable()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 ---
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 ---
 - true
 ...
@@ -239,7 +239,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 200
+- 100
 ...
 -- Return 1%.
 cfg.rebalancer_disbalance_threshold = 0.01
@@ -256,15 +256,15 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ---
-- [101, 'active']
+- [51, 'active']
 ...
 _bucket.index.status:max({vshard.consts.BUCKET.ACTIVE})
 ---
-- [200, 'active']
+- [100, 'active']
 ...
 test_run:switch('box_2_a')
 ---
@@ -272,7 +272,7 @@ test_run:switch('box_2_a')
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ---
@@ -280,7 +280,7 @@ _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ...
 _bucket.index.status:max({vshard.consts.BUCKET.ACTIVE})
 ---
-- [100, 'active', null, {'generation': 2}]
+- [50, 'active', null, {'generation': 2}]
 ...
 --
 -- After multiple rebalancing a next rebalance must not change
@@ -323,9 +323,9 @@ test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
 ---
 ...
-_bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.RECEIVING}})
+_bucket:update({100}, {{'=', 2, vshard.consts.BUCKET.RECEIVING}})
 ---
-- [150, 'receiving']
+- [100, 'receiving']
 ...
 -- We should not check the certain status of buckets (e.g. receiving) because
 -- in rare cases we accidentally can get the wrong one. For example we wait for
@@ -335,7 +335,7 @@ err_msg = string.format('Replica .* has receiving buckets during rebalancing')
 ...
 wait_rebalancer_state('Error during downloading rebalancer states:.*' ..  \
                       err_msg, test_run)                                  \
-_bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
+_bucket:update({100}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 ---
 ...
 vshard.storage.sync()
@@ -360,35 +360,35 @@ test_run:switch('box_1_a')
 vshard.storage.rebalancer_disable()
 ---
 ...
-for i = 91, 100 do wait_bucket_is_collected(i) end
+for i = 41, 50 do wait_bucket_is_collected(i) end
 ---
 ...
-vshard.storage.bucket_force_create(91, 10)
+vshard.storage.bucket_force_create(41, 10)
 ---
 - true
 ...
 space = box.space.test
 ---
 ...
-space:replace{1, 91}
+space:replace{1, 41}
 ---
-- [1, 91]
+- [1, 41]
 ...
-space:replace{2, 92}
+space:replace{2, 42}
 ---
-- [2, 92]
+- [2, 42]
 ...
-space:replace{3, 93}
+space:replace{3, 43}
 ---
-- [3, 93]
+- [3, 43]
 ...
-space:replace{4, 150}
+space:replace{4, 50}
 ---
-- [4, 150]
+- [4, 50]
 ...
-space:replace{5, 151}
+space:replace{5, 51}
 ---
-- [5, 151]
+- [5, 51]
 ...
 test_run:switch('default')
 ---
@@ -404,7 +404,7 @@ test_run:switch('box_2_a')
 space = box.space.test
 ---
 ...
-for i = 91, 100 do _bucket:delete{i} end
+for i = 41, 50 do _bucket:delete{i} end
 ---
 ...
 vshard.storage.sync()
@@ -422,7 +422,7 @@ test_run:switch('box_1_a')
 ---
 - true
 ...
-_bucket:get{91}.status
+_bucket:get{41}.status
 ---
 - active
 ...
@@ -436,7 +436,7 @@ vshard.storage.rebalancer_wakeup()
 -- Now rebalancer makes a bucket SENT. After it the garbage
 -- collector cleans it and deletes after a timeout.
 --
-wait_bucket_is_collected(91)
+wait_bucket_is_collected(41)
 ---
 ...
 wait_rebalancer_state("The cluster is balanced ok", test_run)
@@ -444,15 +444,15 @@ wait_rebalancer_state("The cluster is balanced ok", test_run)
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ---
-- [101, 'active']
+- [51, 'active']
 ...
 _bucket.index.status:max({vshard.consts.BUCKET.ACTIVE})
 ---
-- [200, 'active']
+- [100, 'active']
 ...
 test_run:switch('box_2_a')
 ---
@@ -460,7 +460,7 @@ test_run:switch('box_2_a')
 ...
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 ---
-- 100
+- 50
 ...
 _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ---
@@ -468,13 +468,14 @@ _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
 ...
 _bucket.index.status:max({vshard.consts.BUCKET.ACTIVE})
 ---
-- [100, 'active', null, {'generation': 1}]
+- [50, 'active', null, {'generation': 1}]
 ...
 space:select{}
 ---
-- - [1, 91]
-  - [2, 92]
-  - [3, 93]
+- - [1, 41]
+  - [2, 42]
+  - [3, 43]
+  - [4, 50]
 ...
 --
 -- Test reconfiguration. On master change the rebalancer can move
@@ -580,7 +581,7 @@ test_run:cmd("setopt delimiter ';'")
 ---
 - true
 ...
-while _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE} ~= 200 do
+while _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE} ~= 50 do
     fiber.sleep(0.1)
     vshard.storage.rebalancer_wakeup()
 end;

--- a/test/rebalancer/rebalancer.test.lua
+++ b/test/rebalancer/rebalancer.test.lua
@@ -49,17 +49,17 @@ vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
 wait_rebalancer_state('Total active bucket count is not equal to total', test_run)
 
 --
--- Fill the cluster with buckets saving the balance 100 buckets
+-- Fill the cluster with buckets saving the balance 50 buckets
 -- per replicaset.
 --
 vshard.storage.rebalancer_disable()
 cfg.rebalancer_max_receiving = 10
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 
 test_run:switch('box_2_a')
 _bucket = box.space._bucket
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 
 test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
@@ -71,7 +71,7 @@ wait_rebalancer_state("The cluster is balanced ok", test_run)
 --
 vshard.storage.rebalancer_disable()
 test_run:switch('box_2_a')
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 
 test_run:switch('default')
 util.map_bucket_protection(test_run, {REPLICASET_1}, false)
@@ -104,7 +104,7 @@ test_run:switch('box_1_a')
 cfg.rebalancer_disbalance_threshold = 300
 vshard.storage.rebalancer_disable()
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 
 test_run:switch('default')
 util.map_bucket_protection(test_run, {REPLICASET_2}, false)
@@ -162,14 +162,14 @@ util.map_bucket_protection(test_run, {REPLICASET_1}, false)
 
 test_run:switch('box_1_a')
 vshard.storage.rebalancer_enable()
-_bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.RECEIVING}})
+_bucket:update({100}, {{'=', 2, vshard.consts.BUCKET.RECEIVING}})
 -- We should not check the certain status of buckets (e.g. receiving) because
 -- in rare cases we accidentally can get the wrong one. For example we wait for
 -- "receiving" status, but get "garbage" due to some previous rebalancer error.
 err_msg = string.format('Replica .* has receiving buckets during rebalancing')
 wait_rebalancer_state('Error during downloading rebalancer states:.*' ..  \
                       err_msg, test_run)                                  \
-_bucket:update({150}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
+_bucket:update({100}, {{'=', 2, vshard.consts.BUCKET.ACTIVE}})
 vshard.storage.sync()
 
 test_run:switch('default')
@@ -181,35 +181,35 @@ util.map_bucket_protection(test_run, {REPLICASET_1}, true)
 --
 test_run:switch('box_1_a')
 vshard.storage.rebalancer_disable()
-for i = 91, 100 do wait_bucket_is_collected(i) end
-vshard.storage.bucket_force_create(91, 10)
+for i = 41, 50 do wait_bucket_is_collected(i) end
+vshard.storage.bucket_force_create(41, 10)
 space = box.space.test
-space:replace{1, 91}
-space:replace{2, 92}
-space:replace{3, 93}
-space:replace{4, 150}
-space:replace{5, 151}
+space:replace{1, 41}
+space:replace{2, 42}
+space:replace{3, 43}
+space:replace{4, 50}
+space:replace{5, 51}
 
 test_run:switch('default')
 util.map_bucket_protection(test_run, {REPLICASET_2}, false)
 
 test_run:switch('box_2_a')
 space = box.space.test
-for i = 91, 100 do _bucket:delete{i} end
+for i = 41, 50 do _bucket:delete{i} end
 vshard.storage.sync()
 
 test_run:switch('default')
 util.map_bucket_protection(test_run, {REPLICASET_2}, true)
 
 test_run:switch('box_1_a')
-_bucket:get{91}.status
+_bucket:get{41}.status
 vshard.storage.rebalancer_enable()
 vshard.storage.rebalancer_wakeup()
 --
 -- Now rebalancer makes a bucket SENT. After it the garbage
 -- collector cleans it and deletes after a timeout.
 --
-wait_bucket_is_collected(91)
+wait_bucket_is_collected(41)
 wait_rebalancer_state("The cluster is balanced ok", test_run)
 _bucket.index.status:count({vshard.consts.BUCKET.ACTIVE})
 _bucket.index.status:min({vshard.consts.BUCKET.ACTIVE})
@@ -268,7 +268,7 @@ vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
 vshard.storage.rebalancer_wakeup()
 _bucket = box.space._bucket
 test_run:cmd("setopt delimiter ';'")
-while _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE} ~= 200 do
+while _bucket.index.status:count{vshard.consts.BUCKET.ACTIVE} ~= 50 do
     fiber.sleep(0.1)
     vshard.storage.rebalancer_wakeup()
 end;

--- a/test/rebalancer/rebalancer_lock_and_pin.result
+++ b/test/rebalancer/rebalancer_lock_and_pin.result
@@ -36,7 +36,7 @@ test_run:switch('box_2_a')
 ---
 - true
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 ---
 - true
 ...
@@ -44,7 +44,7 @@ test_run:switch('box_1_a')
 ---
 - true
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -100,7 +100,7 @@ info = vshard.storage.info().bucket
 ...
 info.active
 ---
-- 100
+- 50
 ...
 info.lock
 ---
@@ -138,7 +138,7 @@ info = vshard.storage.info().bucket
 ...
 info.active
 ---
-- 100
+- 50
 ...
 info.lock
 ---
@@ -162,7 +162,7 @@ test_run:switch('box_2_a')
 ...
 -- Does not allow to receive either. Send from a non-locked replicaset to a
 -- locked one fails.
-vshard.storage.bucket_send(101, util.replicasets[1])
+vshard.storage.bucket_send(51, util.replicasets[1])
 ---
 - null
 - type: ShardingError
@@ -310,7 +310,7 @@ info = vshard.storage.info().bucket
 ...
 info.active
 ---
-- 100
+- 50
 ...
 info.lock
 ---
@@ -322,7 +322,7 @@ test_run:switch('box_2_a')
 ...
 vshard.storage.info().bucket.active
 ---
-- 33
+- 16
 ...
 test_run:switch('box_3_a')
 ---
@@ -330,7 +330,7 @@ test_run:switch('box_3_a')
 ...
 vshard.storage.info().bucket.active
 ---
-- 67
+- 34
 ...
 --
 -- Test bucket pinning. At first, return to the default
@@ -398,7 +398,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 vshard.storage.info().bucket.active
 ---
-- 66
+- 33
 ...
 status = box.space._bucket.index.status
 ---
@@ -507,10 +507,10 @@ vshard.storage.bucket_pin(first_id)
 vshard.storage.bucket_send(first_id, util.replicasets[2])
 ---
 - null
-- bucket_id: 35
+- bucket_id: 18
   code: 24
   type: ShardingError
-  message: Bucket 35 is pinned
+  message: Bucket 18 is pinned
   name: BUCKET_IS_PINNED
 ...
 vshard.storage.bucket_unpin(first_id)
@@ -522,12 +522,12 @@ vshard.storage.bucket_unpin(first_id)
 -- rebalancer will face with unreachability of the perfect
 -- balance.
 --
-for i = 1, 60 do local ok, err = vshard.storage.bucket_pin(first_id - 1 + i) assert(ok) end
+for i = 1, 33 do local ok, err = vshard.storage.bucket_pin(first_id - 1 + i) assert(ok) end
 ---
 ...
 status:count({vshard.consts.BUCKET.PINNED})
 ---
-- 60
+- 33
 ...
 rs1_cfg.weight = 0.5
 ---
@@ -545,11 +545,11 @@ info = vshard.storage.info().bucket
 ...
 info.active
 ---
-- 60
+- 33
 ...
 info.pinned
 ---
-- 60
+- 33
 ...
 test_run:switch('box_2_a')
 ---
@@ -557,7 +557,7 @@ test_run:switch('box_2_a')
 ...
 vshard.storage.info().bucket.active
 ---
-- 70
+- 33
 ...
 test_run:switch('box_3_a')
 ---
@@ -565,7 +565,7 @@ test_run:switch('box_3_a')
 ...
 vshard.storage.info().bucket.active
 ---
-- 70
+- 34
 ...
 test_run:cmd("switch default")
 ---

--- a/test/rebalancer/rebalancer_lock_and_pin.test.lua
+++ b/test/rebalancer/rebalancer_lock_and_pin.test.lua
@@ -17,10 +17,10 @@ util.map_evals(test_run, {REPLICASET_1, REPLICASET_2}, 'bootstrap_storage(\'memt
 --
 
 test_run:switch('box_2_a')
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 
 test_run:switch('box_1_a')
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 
 wait_rebalancer_state('The cluster is balanced ok', test_run)
 
@@ -72,7 +72,7 @@ vshard.storage.bucket_send(1, util.replicasets[2])
 test_run:switch('box_2_a')
 -- Does not allow to receive either. Send from a non-locked replicaset to a
 -- locked one fails.
-vshard.storage.bucket_send(101, util.replicasets[1])
+vshard.storage.bucket_send(51, util.replicasets[1])
 
 --
 -- Vshard ensures that if a replicaset is locked, then it will not
@@ -231,7 +231,7 @@ vshard.storage.bucket_unpin(first_id)
 -- rebalancer will face with unreachability of the perfect
 -- balance.
 --
-for i = 1, 60 do local ok, err = vshard.storage.bucket_pin(first_id - 1 + i) assert(ok) end
+for i = 1, 33 do local ok, err = vshard.storage.bucket_pin(first_id - 1 + i) assert(ok) end
 status:count({vshard.consts.BUCKET.PINNED})
 rs1_cfg.weight = 0.5
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)

--- a/test/rebalancer/rebalancer_utils.lua
+++ b/test/rebalancer/rebalancer_utils.lua
@@ -5,7 +5,7 @@ local write_iterations = 0
 local read_iterations = 0
 local write_fiber = 'none'
 local read_fiber = 'none'
-local bucket_count = 200
+local bucket_count = 100
 -- Set just any limit to ensure it is at least not infinite. We want our disk to
 -- have space even if the test runs too long somewhy.
 local primary_key_max = 10000

--- a/test/rebalancer/receiving_bucket.result
+++ b/test/rebalancer/receiving_bucket.result
@@ -38,7 +38,7 @@ _ = test_run:switch('box_1_a')
 _bucket = box.space._bucket
 ---
 ...
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 ---
 - true
 ...
@@ -48,7 +48,7 @@ _ = test_run:switch('box_2_a')
 _bucket = box.space._bucket
 ---
 ...
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 ---
 - true
 ...
@@ -228,7 +228,7 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 _ = test_run:switch('box_2_a')
 ---
 ...
-_, err = vshard.storage.bucket_send(101, util.replicasets[1],                   \
+_, err = vshard.storage.bucket_send(51, util.replicasets[1],                   \
                                     {chunk_timeout = 0.1})
 ---
 ...
@@ -236,7 +236,7 @@ util.is_timeout_error(err)
 ---
 - true
 ...
-wait_bucket_is_collected(101)
+wait_bucket_is_collected(51)
 ---
 ...
 _ = test_run:switch('box_1_a')
@@ -247,7 +247,7 @@ vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
 ...
 test_run:wait_cond(function()                                                   \
     vshard.storage.recovery_wakeup()                                            \
-    return box.space._bucket:get{101}.status == vshard.consts.BUCKET.ACTIVE     \
+    return box.space._bucket:get{51}.status == vshard.consts.BUCKET.ACTIVE     \
 end)
 ---
 - true

--- a/test/rebalancer/receiving_bucket.test.lua
+++ b/test/rebalancer/receiving_bucket.test.lua
@@ -18,11 +18,11 @@ util.push_rs_filters(test_run)
 
 _ = test_run:switch('box_1_a')
 _bucket = box.space._bucket
-vshard.storage.bucket_force_create(1, 100)
+vshard.storage.bucket_force_create(1, 50)
 
 _ = test_run:switch('box_2_a')
 _bucket = box.space._bucket
-vshard.storage.bucket_force_create(101, 100)
+vshard.storage.bucket_force_create(51, 50)
 create_simple_space('test3', {engine = 'vinyl'})
 create_simple_space('test4')
 create_simple_space('test5', {engine = 'vinyl'})
@@ -94,15 +94,15 @@ box.space._bucket:get{1}
 _ = test_run:switch('box_1_a')
 vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = true
 _ = test_run:switch('box_2_a')
-_, err = vshard.storage.bucket_send(101, util.replicasets[1],                   \
+_, err = vshard.storage.bucket_send(51, util.replicasets[1],                   \
                                     {chunk_timeout = 0.1})
 util.is_timeout_error(err)
-wait_bucket_is_collected(101)
+wait_bucket_is_collected(51)
 _ = test_run:switch('box_1_a')
 vshard.storage.internal.errinj.ERRINJ_LAST_RECEIVE_DELAY = false
 test_run:wait_cond(function()                                                   \
     vshard.storage.recovery_wakeup()                                            \
-    return box.space._bucket:get{101}.status == vshard.consts.BUCKET.ACTIVE     \
+    return box.space._bucket:get{51}.status == vshard.consts.BUCKET.ACTIVE     \
 end)
 
 --

--- a/test/rebalancer/restart_during_rebalancing.result
+++ b/test/rebalancer/restart_during_rebalancing.result
@@ -89,7 +89,7 @@ vshard.storage.rebalancer_disable()
 log.info(string.rep('a', 1000))
 ---
 ...
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 ---
 - true
 ...
@@ -202,7 +202,7 @@ test_run:switch('router_1')
 start = fiber.time()
 ---
 ...
-while vshard.router.info().bucket.available_rw ~= 200 do vshard.router.discovery_wakeup() fiber.sleep(0.1) end
+while vshard.router.info().bucket.available_rw ~= 100 do vshard.router.discovery_wakeup() fiber.sleep(0.1) end
 ---
 ...
 fiber.sleep(10 - (fiber.time() - start))
@@ -233,7 +233,7 @@ test_run:cmd("setopt delimiter ''");
 ...
 total_available_rw
 ---
-- 200
+- 100
 ...
 info
 ---
@@ -282,7 +282,7 @@ info
     unreachable: 0
     available_ro: 0
     unknown: 0
-    available_rw: 200
+    available_rw: 100
   identification_mode: uuid_as_key
   status: 0
   is_enabled: true
@@ -302,8 +302,8 @@ test_run:switch('fullbox_1_a')
 vshard.storage.info().bucket
 ---
 - receiving: 0
-  active: 50
-  total: 50
+  active: 25
+  total: 25
   garbage: 0
   pinned: 0
   readonly: 0
@@ -320,8 +320,8 @@ test_run:switch('fullbox_2_a')
 vshard.storage.info().bucket
 ---
 - receiving: 0
-  active: 50
-  total: 50
+  active: 25
+  total: 25
   garbage: 0
   pinned: 0
   readonly: 0
@@ -338,8 +338,8 @@ test_run:switch('fullbox_3_a')
 vshard.storage.info().bucket
 ---
 - receiving: 0
-  active: 50
-  total: 50
+  active: 25
+  total: 25
   garbage: 0
   pinned: 0
   readonly: 0
@@ -356,8 +356,8 @@ test_run:switch('fullbox_4_a')
 vshard.storage.info().bucket
 ---
 - receiving: 0
-  active: 50
-  total: 50
+  active: 25
+  total: 25
   garbage: 0
   pinned: 0
   readonly: 0

--- a/test/rebalancer/restart_during_rebalancing.test.lua
+++ b/test/rebalancer/restart_during_rebalancing.test.lua
@@ -38,7 +38,7 @@ vshard.router.cfg(cfg)
 test_run:switch('fullbox_1_a')
 vshard.storage.rebalancer_disable()
 log.info(string.rep('a', 1000))
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('router_1')
 for i = 1, 4 do vshard.router.discovery_wakeup() end
@@ -105,7 +105,7 @@ while killer:status() ~= 'dead' do fiber.sleep(0.1) end
 test_run:switch('router_1')
 -- Wait until all GC, recovery-discovery finish work.
 start = fiber.time()
-while vshard.router.info().bucket.available_rw ~= 200 do vshard.router.discovery_wakeup() fiber.sleep(0.1) end
+while vshard.router.info().bucket.available_rw ~= 100 do vshard.router.discovery_wakeup() fiber.sleep(0.1) end
 fiber.sleep(10 - (fiber.time() - start))
 info = vshard.router.info()
 total_available_rw = 0

--- a/test/rebalancer/stress_add_remove_rs.result
+++ b/test/rebalancer/stress_add_remove_rs.result
@@ -56,7 +56,7 @@ test_run:switch('box_2_a')
 ---
 - true
 ...
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 ---
 - true
 ...
@@ -72,7 +72,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 100
+- 50
 ...
 --
 -- Test the first case of described above.
@@ -180,7 +180,7 @@ wait_rebalancer_state('The cluster is balanced ok', test_run)
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 66
+- 33
 ...
 test_run:switch('router_1')
 ---
@@ -199,7 +199,7 @@ test_run:switch('box_1_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 66
+- 33
 ...
 check_consistency()
 ---
@@ -211,7 +211,7 @@ test_run:switch('box_2_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 67
+- 33
 ...
 check_consistency()
 ---
@@ -223,7 +223,7 @@ test_run:switch('box_3_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 67
+- 34
 ...
 check_consistency()
 ---
@@ -358,7 +358,7 @@ test_run:switch('box_1_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 100
+- 50
 ...
 check_consistency()
 ---
@@ -370,7 +370,7 @@ test_run:switch('box_2_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 100
+- 50
 ...
 check_consistency()
 ---

--- a/test/rebalancer/stress_add_remove_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_rs.test.lua
@@ -26,7 +26,7 @@ test_run:switch('router_1')
 -- data, that were written during the step execution.
 --
 test_run:switch('box_2_a')
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('box_1_a')
 vshard.storage.cfg(cfg, util.name_to_uuid.box_1_a)

--- a/test/rebalancer/stress_add_remove_several_rs.result
+++ b/test/rebalancer/stress_add_remove_several_rs.result
@@ -66,7 +66,7 @@ cfg.rebalancer_max_receiving = 2
 vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
 ---
 ...
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 ---
 - true
 ...
@@ -307,7 +307,7 @@ test_run:switch('box_1_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 50
+- 25
 ...
 check_consistency()
 ---
@@ -319,7 +319,7 @@ test_run:switch('box_2_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 50
+- 25
 ...
 check_consistency()
 ---
@@ -331,7 +331,7 @@ test_run:switch('box_3_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 50
+- 25
 ...
 check_consistency()
 ---
@@ -343,7 +343,7 @@ test_run:switch('box_4_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 50
+- 25
 ...
 check_consistency()
 ---
@@ -507,7 +507,7 @@ test_run:switch('box_1_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 100
+- 50
 ...
 check_consistency()
 ---
@@ -519,7 +519,7 @@ test_run:switch('box_2_a')
 ...
 #box.space._bucket.index.status:select{vshard.consts.BUCKET.ACTIVE}
 ---
-- 100
+- 50
 ...
 check_consistency()
 ---

--- a/test/rebalancer/stress_add_remove_several_rs.test.lua
+++ b/test/rebalancer/stress_add_remove_several_rs.test.lua
@@ -31,7 +31,7 @@ test_run:switch('router_1')
 test_run:switch('box_2_a')
 cfg.rebalancer_max_receiving = 2
 vshard.storage.cfg(cfg, util.name_to_uuid.box_2_a)
-vshard.storage.bucket_force_create(1, 200)
+vshard.storage.bucket_force_create(1, 100)
 
 test_run:switch('box_1_a')
 cfg.rebalancer_max_receiving = 2

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -336,6 +336,7 @@ local function master_call(replicaset, func, args, opts)
     local deadline = fiber_clock() + opts.timeout
     local did_first_attempt = false
     while true do
+        lfiber.testcancel()
         local res, err = replicaset:callrw(func, args, opts)
         if res ~= nil then
             return res
@@ -1131,7 +1132,6 @@ local function recovery_step_by_type(type, limiter)
             end
             goto continue
         end
-        lfiber.testcancel()
         remote_bucket, err = master_call(
             destination, 'vshard.storage._call',
             {'recovery_bucket_stat', bucket_id},
@@ -3230,7 +3230,6 @@ local function rebalancer_service_f(service, limiter)
         for src_id, src_routes in pairs(routes) do
             service:set_activity('applying routes')
             local rs = M.replicasets[src_id]
-            lfiber.testcancel()
             local status, err = master_call(
                 rs, 'vshard.storage.rebalancer_apply_routes', {src_routes},
                 {timeout = consts.REBALANCER_APPLY_ROUTES_TIMEOUT})


### PR DESCRIPTION
After the commit `storage: check for refs on replicas before sending a bucket`, the rebalancing time increased significantly due to the introduction of `bucket_test_send` and `bucket_test_send_on_replicas` functions. Consequently, the duration of the rebalancer tests has also increased (e.g. the average execution time for the `restart_during_rebalancing` was about 30 seconds before that, but now it's 90 seconds). As a result, some rebalancer tests started to fail in vshard and other CI (more details are given in issue ticket).

In order to fix the flakiness we reduce the amount of buckets which we create in cluster in rebalancer tests from `200` to `100`. We change this value not only in `restart_during_rebalancing` test, but also in all tests in order to prevent hypothetical flakiness of other tests.

Closes tarantool/vshard#652

NO_TEST=test
NO_DOC=test