### PR TITLE
storage: resume bucket GC iterators after commits

### DIFF
--- a/test/storage-luatest/garbage_collector_test.lua
+++ b/test/storage-luatest/garbage_collector_test.lua
@@ -1074,3 +1074,156 @@ test_group.test_route_map_is_cleared = function(g)
     vtest.cluster_wait_vclock_all(g)
     g.replica_1_b:exec(bucket_set_protection, {true})
 end
+
+--
+-- gh-661: bucket GC resumes after the last tuple deleted by the preceding
+-- transaction on Tarantool versions with index pagination. Older versions and
+-- indexes that do not support positions keep restarting from the bucket prefix.
+--
+local function test_resumable_cursor_template(g, expected_resumes)
+    g.replica_1_a:exec(function(expected_resumes)
+        _G.bucket_gc_pause()
+        local s = box.space.test
+        local bucket_index = s.index.bucket_id
+        local bid = _G.get_first_bucket()
+        local old_chunk_size = ivconst.BUCKET_CHUNK_SIZE
+        local old_pairs = bucket_index.pairs
+        local chunk_size = 10
+        local tuple_count = chunk_size * 2 + 5
+
+        -- Two full chunks and a non-empty tail make GC open three iterators.
+        -- Record whether each one resumed from a position (1) or restarted at
+        -- the bucket prefix (0). The first iterator always starts at the
+        -- prefix. The next two resume only on cores with index pagination.
+        -- 'after' is opaque, so its presence is the observable signal.
+        local resumes = {}
+        bucket_index.pairs = function(self, key, opts)
+            local after = opts and opts.after
+            table.insert(resumes, after ~= nil and 1 or 0)
+            return old_pairs(self, key, opts)
+        end
+
+        local ok, err = pcall(function()
+            ivconst.BUCKET_CHUNK_SIZE = chunk_size
+            box.begin()
+            for i = 1, tuple_count do
+                s:replace{100000 + i, bid}
+            end
+            box.commit()
+            ivshard.storage.bucket_delete_garbage(bid, {force = true})
+            ilt.assert_equals(bucket_index:count({bid}), 0)
+            ilt.assert_equals(resumes, expected_resumes)
+        end)
+
+        bucket_index.pairs = old_pairs
+        ivconst.BUCKET_CHUNK_SIZE = old_chunk_size
+        _G.bucket_gc_continue()
+        ilt.assert(ok, err)
+    end, {expected_resumes})
+    vtest.cluster_wait_vclock_all(g)
+end
+
+--
+-- gh-661: pagination-capable cores resume the second and third iterators after
+-- the preceding chunk instead of restarting at the bucket prefix.
+--
+test_group.test_resumable_cursor_supported = function(g)
+    t.run_only_if(vutil.feature.index_pagination)
+    test_resumable_cursor_template(g, {0, 1, 1})
+end
+
+--
+-- gh-661: without index pagination (Tarantool < 2.11) every iterator restarts
+-- at the bucket prefix.
+--
+test_group.test_resumable_cursor_unsupported = function(g)
+    t.run_only_if(not vutil.feature.index_pagination)
+    test_resumable_cursor_template(g, {0, 0, 0})
+end
+
+--
+-- gh-661: functional and multikey sharding indexes report type == 'TREE' and
+-- pass find_sharded_spaces(), but reject positions with "does not support
+-- position by tuple"; hash indexes are not TREE at all. GC must fall back to
+-- restarting from the bucket prefix for them and still delete the bucket.
+--
+test_group.test_resumable_cursor_unsupported_index = function(g)
+    t.run_only_if(vutil.feature.index_pagination)
+    g.replica_1_a:exec(function()
+        _G.bucket_gc_pause()
+        local bid = _G.get_first_bucket()
+        local spaces = {}
+        local func_name = 'test_extract_bucket'
+        local old_chunk_size = ivconst.BUCKET_CHUNK_SIZE
+
+        -- Each case fills exactly one chunk, so GC has to open a second
+        -- iterator after committing the delete. Cleanup succeeds only if an
+        -- index which cannot derive a position from a tuple falls back to
+        -- restarting at the bucket prefix.
+        local function run(name, space_opts, index_opts, tuple)
+            local space = box.schema.create_space(name, space_opts)
+            table.insert(spaces, space)
+            space:create_index('pk')
+            space:create_index('bucket_id', index_opts)
+            space:replace(tuple)
+            ivshard.storage.bucket_delete_garbage(bid, {force = true})
+            ilt.assert_equals(space:count(), 0)
+            space:drop()
+            spaces[#spaces] = nil
+        end
+
+        local ok, err = pcall(function()
+            ivconst.BUCKET_CHUNK_SIZE = 1
+
+            run('test_hash', {
+                engine = 'memtx',
+                format = {{'id', 'unsigned'}, {'bid', 'unsigned'}},
+            }, {
+                type = 'hash', unique = true, parts = {2},
+            }, {300000, bid})
+
+            run('test_multikey', {
+                engine = 'vinyl',
+                format = {
+                    {'id', 'unsigned'},
+                    {'bid', 'unsigned'},
+                    {'tags', 'array'},
+                },
+            }, {
+                unique = false,
+                parts = {
+                    {field = 2, type = 'unsigned'},
+                    {field = 3, type = 'string', path = '[*]'},
+                },
+            }, {300001, bid, {'tag'}})
+
+            -- Memtx MVCC does not support functional indexes.
+            if not box.cfg.memtx_use_mvcc_engine then
+                box.schema.func.create(func_name, {
+                    body = [[function(tuple) return {tuple[2]} end]],
+                    is_deterministic = true,
+                    is_sandboxed = true,
+                })
+                run('test_functional', {
+                    engine = 'memtx',
+                    format = {{'id', 'unsigned'}, {'bid', 'unsigned'}},
+                }, {
+                    unique = false,
+                    func = func_name,
+                    parts = {{field = 1, type = 'unsigned'}},
+                }, {300002, bid})
+            end
+        end)
+
+        ivconst.BUCKET_CHUNK_SIZE = old_chunk_size
+        for _, space in ipairs(spaces) do
+            space:drop()
+        end
+        if box.func[func_name] ~= nil then
+            box.schema.func.drop(func_name)
+        end
+        _G.bucket_gc_continue()
+        ilt.assert(ok, err)
+    end)
+    vtest.cluster_wait_vclock_all(g)
+end

--- a/vshard/storage/init.lua
+++ b/vshard/storage/init.lua
@@ -2351,20 +2351,26 @@ end
 --
 local function gc_bucket_in_space_xc(space, bucket_id, status)
     local bucket_index = space.index[lschema.shard_index]
-    if #bucket_index:select({bucket_id}, {limit = 1}) == 0 then
+    local first = bucket_index:select({bucket_id}, {limit = 1})[1]
+    if first == nil then
         return
     end
     local bucket_generation = M.bucket_generation
     local pk_parts = space.index[0].parts
+    local use_cursor = util.index_can_paginate(bucket_index, first)
+    local after
 ::restart::
     local limit = consts.BUCKET_CHUNK_SIZE
     box.begin()
     M._on_bucket_event:run(consts.BUCKET_EVENT.GC, bucket_id,
                            {spaces = {space.name}})
-    for _, tuple in bucket_index:pairs({bucket_id}) do
+    for _, tuple in bucket_index:pairs({bucket_id}, {after = after}) do
         space:delete(util.tuple_extract_key(tuple, pk_parts))
         limit = limit - 1
         if limit == 0 then
+            if use_cursor then
+                after = bucket_index:tuple_pos(tuple)
+            end
             box.commit()
             bucket_generation =
                 bucket_guard_xc(bucket_generation, bucket_id, status)

--- a/vshard/util.lua
+++ b/vshard/util.lua
@@ -438,6 +438,7 @@ end
 local feature = {
     msgpack_object = lmsgpack.object ~= nil,
     netbox_return_raw = version_is_at_least(2, 10, 0, 'beta', 2, 86),
+    index_pagination = version_is_at_least(2, 11, 0, nil, 0, 0),
     multilisten = luri.parse_many ~= nil,
     -- It appeared earlier but at 2.9.0 there is a strange bug about an immortal
     -- tuple - after :delete(pk) it still stays in the space. That makes the
@@ -473,6 +474,19 @@ local feature = {
         return ok1 and ok2
     end)(),
 }
+
+--
+-- Check whether an index supports pagination using a tuple position. Pagination
+-- is a TREE index feature, but functional and multikey TREE indexes reject
+-- tuple positions. Probe the index so callers can safely fall back.
+--
+local function index_can_paginate(index, tuple)
+    if not feature.index_pagination or index.type ~= 'TREE' then
+        return false
+    end
+    local ok = pcall(index.tuple_pos, index, tuple)
+    return ok
+end
 
 local schema_version = function()
     return box.info.schema_version
@@ -587,6 +601,7 @@ return {
     fiber_is_self_canceled = fiber_is_self_canceled,
     index_min = index_min,
     index_has = index_has,
+    index_can_paginate = index_can_paginate,
     feature = feature,
     schema_version = schema_version,
     replicaset_uuid = replicaset_uuid,


### PR DESCRIPTION
# Resume bucket GC iteration across transaction batches

## Summary

This change avoids restarting bucket garbage-collection scans from the bucket prefix after every transaction. On Tarantool 2.11 and later, GC over a TREE bucket index now retains the last tuple committed by a full batch and passes it as the next iterator's `after` position. Older Tarantool versions and unsupported index types retain the existing prefix-restarting path.

Closes #661 

## Motivation

Bucket GC commits after `BUCKET_CHUNK_SIZE` deletes and then opens another iterator at `{bucket_id}`. For large Vinyl buckets, every new secondary-index iterator can revisit the tombstones and LSM history left by preceding batches before it reaches the next live tuple. Smaller transaction batches create more restarts and can therefore cause disproportionate cleanup CPU and wall time.

Tarantool pagination supports resuming after a tuple that is no longer present in the index. Retaining the last committed tuple allows the next transaction to continue at the correct secondary-index position without changing delete, WAL, replication, transaction, trigger, or bucket-state semantics.

## Changes

- Add an `index_pagination` core feature flag for Tarantool 2.11 and later.
- Resume bucket GC from the last tuple committed by the preceding full batch when the sharding index is a TREE index and pagination is supported.
- Preserve the current prefix-restarting behavior on Tarantool 1.10 and unsupported index types.
- Keep the cursor local to one bucket and one space.
- Continue checking the bucket generation and state after every full-batch commit.
- Add tests that verify the initial prefix scan, subsequent `after` positions, the pagination-disabled fallback, and the non-TREE fallback.

## Compatibility

There is no configuration or public API change. Tarantool versions before 2.11 never receive the `after` iterator option and retain the current implementation. The optimization is also disabled for non-TREE sharding indexes.

A garbage bucket is not writable through VShard while cleanup runs. Cursor resumption relies on the same lifecycle invariant as bucket sending: no tuples are inserted behind an iterator that has already passed their position.

## Performance

A representative local benchmark used a 50,000-tuple Vinyl bucket with three indexes, synchronous replication, and a garbage-collection transaction size of 100. Values are medians across three fresh-cluster runs.

| Iteration behavior | Cleanup wall time | Cleanup CPU time |
|---|---:|---:|
| Restart from bucket prefix | 4.906 s | 4.757 s |
| Resume after last tuple | 0.602 s | 0.414 s |

The optimization reduced cleanup wall time by approximately 88% and cleanup CPU by approximately 91%. It did not change the number of deletes, WAL rows, transactions, index updates, or synchronous commits.

## Testing

- New resumable-cursor test passes for MemTX and Vinyl, with and without MVCC.
- The test verifies the pagination-enabled cursor positions and forces the pagination-disabled fallback.
- The test verifies that a HASH sharding index retains the non-cursor path.
- Complete garbage-collector suite: 46 passed, 2 skipped.
- Luacheck 0.26.1: 0 warnings and 0 errors across 61 files.